### PR TITLE
Dependabot gruppering etter patch, minor and major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,23 +18,34 @@ updates:
     registries:
       - familie-felles
     groups:
-      minor-and-patch-dependencies:
-        patterns:
-          - "*"
+      patch-dependencies:
+        update-types:
+          - "patch"
+      minor-dependencies:
         update-types:
           - "minor"
-          - "patch"
-      major-dependencies:
+      per-major-dependency:
         patterns:
           - "*"
         update-types:
           - "major"
-      all-dependencies:
-        patterns:
-          - "*"
+        group-name-separator: "-"
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
       day: "sunday"
       time: "04:00"
+    open-pull-requests-limit: 10
+    groups:
+      patch-dependencies:
+        update-types:
+          - "patch"
+      minor-dependencies:
+        update-types:
+          - "minor"
+      major-dependencies:
+        update-types:
+          - "major"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,7 +63,7 @@ updates:
           - "io.mockk:mockk"
         update-types:
           - "major"
-      # Catch-all for all other dependencies, handled as one PR per dependency
+      # Fang opp alle andre avhengigheter, håndtert som én PR per avhengighet
       per-major-dependency:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       interval: weekly
       day: "sunday"
       time: "04:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 12
     registries:
       - familie-felles
     groups:
@@ -24,6 +24,46 @@ updates:
       minor-dependencies:
         update-types:
           - "minor"
+      kotlin-dependencies:
+        patterns:
+          - "org.jetbrains.kotlin:*"
+        update-types:
+          - "major"
+      spring-boot-dependencies:
+        patterns:
+          - "org.springframework.boot:*"
+        update-types:
+          - "major"
+      springdoc-dependencies:
+        patterns:
+          - "org.springdoc:*"
+        update-types:
+          - "major"
+      jackson-dependencies:
+        patterns:
+          - "com.fasterxml.jackson.module:*"
+          - "com.fasterxml.jackson.datatype:*"
+        update-types:
+          - "major"
+      nav-internal-dependencies:
+        patterns:
+          - "no.nav.familie.felles:*"
+          - "no.nav.security:*"
+        update-types:
+          - "major"
+      itext-dependencies:
+        patterns:
+          - "com.itextpdf:*"
+        update-types:
+          - "major"
+      junit-and-testing-dependencies:
+        patterns:
+          - "org.junit.jupiter:*"
+          - "org.jetbrains.kotlin:kotlin-test-junit5"
+          - "io.mockk:mockk"
+        update-types:
+          - "major"
+      # Catch-all for all other dependencies, handled as one PR per dependency
       per-major-dependency:
         patterns:
           - "*"
@@ -48,4 +88,3 @@ updates:
       major-dependencies:
         update-types:
           - "major"
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,7 +69,6 @@ updates:
           - "*"
         update-types:
           - "major"
-        group-name-separator: "-"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
**🎉 Oppdatering av Dependabot-konfigurasjon**

**Hva er gjort?**
Denne PR-en oppdaterer Dependabot-konfigurasjonen for å forbedre hvordan avhengighetsoppdateringer håndteres. Endringene inkluderer:


- Separate PR-er for major-oppdateringer:
      - Hver major avhengighetsoppdatering vil nå opprettes som en egen PR, noe som gir bedre kontroll og oversikt over store endringer.
- Gruppering av minor- og patch-oppdateringer:
      -  patch-oppdateringer samles i én PR.
      - minor-oppdateringer samles i en annen PR.

**Hvorfor er dette nyttig?**
Økt oversiktlighet: Ved å håndtere major-oppdateringer separat, kan vi bedre evaluere potensielle breaking changes og tilhørende risiko.
Effektiv oppdateringsflyt: Mindre endringer (patch og minor) håndteres samlet for å redusere antall PR-er og opprettholde kontinuerlige oppdateringer.