### PR TITLE
Linjeskift adresse

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -17,7 +17,9 @@ object PdfElementUtils {
 
     fun lagVerdiElement(element: Map<*, *>): Paragraph =
         Paragraph().apply {
-            (element["label"] as? String).takeIf { it?.isNotEmpty() == true }?.let { add(Text(it).apply { simulateBold() }) }
+            (element["label"] as? String)
+                .takeIf { it?.isNotEmpty() == true }
+                ?.let { add(Text(it).apply { simulateBold() }) }
             (element["alternativer"] as? String)?.takeIf { it.isNotEmpty() }?.let {
                 add(Text("\n"))
                 add(
@@ -28,11 +30,27 @@ object PdfElementUtils {
                 )
             }
             add(Text("\n"))
-            add(Text(element["verdi"].toString()))
+            if (element["label"] == "Adresse") {
+                add(sjekkDobbelLinjeskift(element["verdi"].toString()))
+            } else {
+                add(element["verdi"].toString())
+            }
             setFontSize(12f)
             isKeepTogether = true
             accessibilityProperties.role = StandardRoles.P
         }
+
+    fun sjekkDobbelLinjeskift(tekst: String): String {
+        val bareLinjeskiftRegex = Regex("^\\n+$")
+        val dobbelLinjeskiftRegex = Regex("\\n{2,}")
+        val rensetVerdi =
+            if (tekst.isEmpty() || tekst.matches(bareLinjeskiftRegex)) {
+                "Ingen registrert adresse"
+            } else {
+                tekst.replace(dobbelLinjeskiftRegex, "\n")
+            }
+        return rensetVerdi
+    }
 
     fun lagTekstElement(tekst: String): Paragraph =
         Paragraph().apply {

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/PdfMedStandarder.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/PdfMedStandarder.kt
@@ -9,7 +9,7 @@ data class PdfMedStandarder(
 
 data class Standard(
     val samsvarer: Boolean,
-    val feiletRegel: String?,
+    val feiletRegel: String,
 )
 
 enum class PdfStandard(

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -5,7 +5,7 @@ import com.itextpdf.kernel.pdf.PdfReader
 import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.pdfa.PdfADocument
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedBareNylinjer
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedBareLinjeskift
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedFlereLinjeskift
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedForskjelligLabelIVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomAdresse
@@ -44,7 +44,7 @@ class PdfServiceTest {
         @JvmStatic
         fun tomAdresse(): Stream<Map<String, Any>> =
             Stream.of(
-                lagAdresseMedBareNylinjer(),
+                lagAdresseMedBareLinjeskift(),
                 lagMedTomAdresse(),
             )
     }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -5,7 +5,10 @@ import com.itextpdf.kernel.pdf.PdfReader
 import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.pdfa.PdfADocument
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedBareNylinjer
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedFlereLinjeskift
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedForskjelligLabelIVerdiliste
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomAdresse
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagNullInnhold
@@ -36,6 +39,13 @@ class PdfServiceTest {
             Stream.of(
                 lagMedVerdiliste(),
                 lagToSiderInnholdsfortegnelse(),
+            )
+
+        @JvmStatic
+        fun tomAdresse(): Stream<Map<String, Any>> =
+            Stream.of(
+                lagAdresseMedBareNylinjer(),
+                lagMedTomAdresse(),
             )
     }
 
@@ -85,10 +95,7 @@ class PdfServiceTest {
         val feltMap = lagMedVerdiliste()
 
         // Act
-        val result = pdfOppretterService.opprettPdf(feltMap)
-        val pdfReader = PdfReader(ByteArrayInputStream(result))
-        val pdfWriter = PdfWriter(ByteArrayOutputStream())
-        val pdfDoc = PdfADocument(pdfReader, pdfWriter)
+        val pdfDoc = opprettPdf(feltMap)
 
         // Assert
         for (pageNumber in 1..pdfDoc.numberOfPages) {
@@ -101,10 +108,7 @@ class PdfServiceTest {
     @MethodSource("innholdsfortegnelseMedEnOgToSider")
     fun `Pdf legger forside med innholdsfortegnelse først`(feltMap: Map<String, Any>) {
         // Act
-        val result = pdfOppretterService.opprettPdf(feltMap)
-        val pdfReader = PdfReader(ByteArrayInputStream(result))
-        val pdfWriter = PdfWriter(ByteArrayOutputStream())
-        val pdfDoc = PdfADocument(pdfReader, pdfWriter)
+        val pdfDoc = opprettPdf(feltMap)
         val førsteSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
 
         // Assert
@@ -118,10 +122,7 @@ class PdfServiceTest {
         forventetSide: Int,
     ) {
         // Act
-        val result = pdfOppretterService.opprettPdf(feltMap)
-        val pdfReader = PdfReader(ByteArrayInputStream(result))
-        val pdfWriter = PdfWriter(ByteArrayOutputStream())
-        val pdfDoc = PdfADocument(pdfReader, pdfWriter)
+        val pdfDoc = opprettPdf(feltMap)
         val firstPageText = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
 
         // Assert
@@ -134,5 +135,35 @@ class PdfServiceTest {
             val actualPageText = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(forventetSide))
             assertTrue(actualPageText.contains(label))
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("tomAdresse")
+    fun `Pdf med innhold i Adresse blir renset for tom og flere linjeskift`(feltMap: Map<String, Any>) {
+        // Act
+        val pdfDoc = opprettPdf(feltMap)
+        val andreSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
+        // Assert
+        assertTrue(andreSideTekst.contains("Ingen registrert adresse"))
+    }
+
+    @Test
+    fun `Pdf med en adresse og flere linjeskift blir redusert til ett linjeskift`() {
+        // Arrange
+        val feltMap = lagAdresseMedFlereLinjeskift()
+        // Act
+        val pdfDoc = opprettPdf(feltMap)
+        val andreSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
+        // Assert
+        // Tror ekstra mellomrommet etter 12 er fordi pdf genereringen legger til en ekstra linje. Debuget og ser aldri hvor den blir lagt til.
+        assertTrue(andreSideTekst.contains("Adresse 12 \n0999 Oslo"))
+    }
+
+    private fun opprettPdf(feltMap: Map<String, Any>): PdfADocument {
+        val result = pdfOppretterService.opprettPdf(feltMap)
+        val pdfReader = PdfReader(ByteArrayInputStream(result))
+        val pdfWriter = PdfWriter(ByteArrayOutputStream())
+        val pdfDoc = PdfADocument(pdfReader, pdfWriter)
+        return pdfDoc
     }
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfValidatorTest.kt
@@ -30,6 +30,6 @@ class PdfValidatorTest {
         val result = PdfValidator.validerPdf(pdfBytes, standard)
         // Assert
         // Spesial-tilfelle fordi regel 8.8-2 ikke er oppfylt ved klikkbar lenke i innholdsfortegnelsen
-        assertTrue(result.feiletRegel == "[[specification=ISO 14289-2:2024 clause=8.8 testNumber=2]=12 ]" || result.samsvarer, "Pdf-en samsvarer ikke med standarden $standard med feilen ${result.feiletRegel}")
+        assertTrue(result.feiletRegel.contains("[specification=ISO 14289-2:2024 clause=8.8 testNumber=2]=12") || result.samsvarer, "Pdf-en samsvarer ikke med standarden $standard med feilen ${result.feiletRegel}")
     }
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -45,7 +45,7 @@ fun lagMedTomAdresse(): Map<String, Any> =
             ),
     )
 
-fun lagAdresseMedBareNylinjer(): Map<String, Any> =
+fun lagAdresseMedBareLinjeskift(): Map<String, Any> =
     mapOf(
         "label" to "Søknad om overgangsstønad",
         "verdiliste" to

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -33,6 +33,42 @@ fun lagMedForskjelligLabelIVerdiliste(): Map<String, Any> =
 
 fun lagNullInnhold(): Map<String, Any?> = mapOf("label" to null, "verdiliste" to null)
 
+fun lagMedTomAdresse(): Map<String, Any> =
+    mapOf(
+        "label" to "Søknad om overgangsstønad",
+        "verdiliste" to
+            listOf(
+                mapOf(
+                    "label" to "Søker",
+                    "verdiliste" to listOf(mapOf("label" to "Adresse", "verdi" to "")),
+                ),
+            ),
+    )
+
+fun lagAdresseMedBareNylinjer(): Map<String, Any> =
+    mapOf(
+        "label" to "Søknad om overgangsstønad",
+        "verdiliste" to
+            listOf(
+                mapOf(
+                    "label" to "Søker",
+                    "verdiliste" to listOf(mapOf("label" to "Adresse", "verdi" to "\n\n\n\n")),
+                ),
+            ),
+    )
+
+fun lagAdresseMedFlereLinjeskift(): Map<String, Any> =
+    mapOf(
+        "label" to "Søknad om overgangsstønad",
+        "verdiliste" to
+            listOf(
+                mapOf(
+                    "label" to "Søker",
+                    "verdiliste" to listOf(mapOf("label" to "Adresse", "verdi" to "Adresse 12\n\n\n\n0999 Oslo")),
+                ),
+            ),
+    )
+
 fun lagToSiderInnholdsfortegnelse(): Map<String, Any> =
     mapOf(
         "label" to "Søknad om overgangsstønad (NAV 15-00.01)",


### PR DESCRIPTION
Tomt innhold eller kun flere linjeskift blir byttet med "Ingen registrert adresse"
Adresse med flere linjeskift i seg blir byttet med kun et linjeskift.
Tester for disse scenarioene. Verifisert med eget øye at det blir sånn på pdf-en også.
![Skjermbilde 2024-12-05 kl  09 54 29](https://github.com/user-attachments/assets/58827b5b-bedb-4f8d-a291-460c9f353564)
Et rart tilfelle: resultatet av `rensetVerdi` er uten mellomrom etter 12. men i testen så blir resultatet med et mellomrom. Har søkt litt på nettet og det ser ut som pdf-generatoren legger til et mellomrom for riktig formatering. Uvisst 🤷🏽‍♂️
<img width="661" alt="Skjermbilde 2024-12-06 kl  08 35 10" src="https://github.com/user-attachments/assets/072679be-389d-41b8-a00e-db4175882f3d">
