### PR TITLE
Typedefinert FeltMap og dens barn

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/JsonLeser.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/JsonLeser.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.nav.familie.pdf.pdf.domain.FeltMap
 import java.io.FileNotFoundException
 import java.io.IOException
 
@@ -13,15 +14,15 @@ object JsonLeser {
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .registerModule(JavaTimeModule())
 
-    fun lesSøknadJson(): Map<String, Any> {
+    fun lesSøknadJson(): FeltMap {
         val jsonInputStream =
             this::class.java.getResourceAsStream("/søknad.json")
                 ?: throw FileNotFoundException("Kan ikke lese søknad.json")
 
         return try {
             jsonInputStream.bufferedReader().use { reader ->
-                val result = objectMapper.readValue(reader, Map::class.java)
-                result as? Map<String, Any> ?: throw ClassCastException("Uventet Json-format")
+                val result = objectMapper.readValue(reader, FeltMap::class.java)
+                result ?: throw ClassCastException("Uventet Json-format")
             }
         } catch (e: IOException) {
             throw RuntimeException("Feil ved lesing av JSON-fil", e)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.pdf.pdf
 
+import jakarta.validation.Valid
 import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PostMapping
@@ -17,6 +18,6 @@ class PdfController {
 
     @PostMapping("/opprett-pdf")
     fun opprettPdf(
-        @RequestBody søknad: FeltMap,
+        @Valid @RequestBody søknad: FeltMap,
     ): ByteArray = pdfService.opprettPdf(søknad)
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.pdf.pdf
 
+import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,6 +17,6 @@ class PdfController {
 
     @PostMapping("/opprett-pdf")
     fun opprettPdf(
-        @RequestBody søknad: Map<String, Any>,
+        @RequestBody søknad: FeltMap,
     ): ByteArray = pdfService.opprettPdf(søknad)
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -6,6 +6,7 @@ import com.itextpdf.kernel.pdf.tagging.StandardRoles
 import com.itextpdf.layout.element.Image
 import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Text
+import no.nav.familie.pdf.pdf.domain.VerdilisteItem
 
 object PdfElementUtils {
     fun navLogoBilde(): Image =
@@ -15,12 +16,12 @@ object PdfElementUtils {
             accessibilityProperties.alternateDescription = "NAV logo"
         }
 
-    fun lagVerdiElement(element: Map<*, *>): Paragraph =
+    fun lagVerdiElement(element: VerdilisteItem): Paragraph =
         Paragraph().apply {
-            (element["label"] as? String)
+            (element.label)
                 .takeIf { it?.isNotEmpty() == true }
                 ?.let { add(Text(it).apply { simulateBold() }) }
-            (element["alternativer"] as? String)?.takeIf { it.isNotEmpty() }?.let {
+            element.alternativer?.takeIf { it.isNotEmpty() }?.let {
                 add(Text("\n"))
                 add(
                     Text(it).apply {
@@ -30,10 +31,10 @@ object PdfElementUtils {
                 )
             }
             add(Text("\n"))
-            if (element["label"] == "Adresse") {
-                add(sjekkDobbelLinjeskift(element["verdi"].toString()))
+            if (element.label == "Adresse" && element.verdi != null) {
+                add(sjekkDobbelLinjeskift(element.verdi))
             } else {
-                add(element["verdi"].toString())
+                add(element.verdi)
             }
             setFontSize(12f)
             isKeepTogether = true

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -6,7 +6,7 @@ import com.itextpdf.kernel.pdf.tagging.StandardRoles
 import com.itextpdf.layout.element.Image
 import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Text
-import no.nav.familie.pdf.pdf.domain.VerdilisteItem
+import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 
 object PdfElementUtils {
     fun navLogoBilde(): Image =
@@ -16,7 +16,7 @@ object PdfElementUtils {
             accessibilityProperties.alternateDescription = "NAV logo"
         }
 
-    fun lagVerdiElement(element: VerdilisteItem): Paragraph =
+    fun lagVerdiElement(element: VerdilisteElement): Paragraph =
         Paragraph().apply {
             (element.label)
                 .takeIf { it?.isNotEmpty() == true }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -7,8 +7,8 @@ import no.nav.familie.pdf.pdf.domain.FeltMap
 
 class PdfService {
     fun opprettPdf(feltMap: FeltMap): ByteArray {
-        requireNotNull(feltMap.label) { "feltMap sitt label er tom." }
-        requireNotNull(feltMap.verdiliste) { "feltMap sittverdiliste er tom." }
+        requireNotNull(feltMap.label) { "FeltMap sitt label er tom." }
+        requireNotNull(feltMap.verdiliste) { "FeltMap sin verdiliste er tom." }
 
         val byteArrayOutputStream = ByteArrayOutputStream()
         val pdfADokument = lagPdfADocument(byteArrayOutputStream)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -3,12 +3,13 @@ package no.nav.familie.pdf.pdf
 import com.itextpdf.io.source.ByteArrayOutputStream
 import no.nav.familie.pdf.pdf.PdfUtils.lagDokument
 import no.nav.familie.pdf.pdf.PdfUtils.lagPdfADocument
+import no.nav.familie.pdf.pdf.domain.FeltMap
 
 class PdfService {
-    fun opprettPdf(feltMap: Map<String, Any>): ByteArray {
-        feltMap.values.forEach { value ->
-            requireNotNull(value) { "feltMap sitt label eller verdiliste er tom." }
-        }
+    fun opprettPdf(feltMap: FeltMap): ByteArray {
+        requireNotNull(feltMap.label) { "feltMap sitt label er tom." }
+        requireNotNull(feltMap.verdiliste) { "feltMap sittverdiliste er tom." }
+
         val byteArrayOutputStream = ByteArrayOutputStream()
         val pdfADokument = lagPdfADocument(byteArrayOutputStream)
         lagDokument(pdfADokument, feltMap)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -7,9 +7,6 @@ import no.nav.familie.pdf.pdf.domain.FeltMap
 
 class PdfService {
     fun opprettPdf(feltMap: FeltMap): ByteArray {
-        requireNotNull(feltMap.label) { "FeltMap sitt label er tom." }
-        requireNotNull(feltMap.verdiliste) { "FeltMap sin verdiliste er tom." }
-
         val byteArrayOutputStream = ByteArrayOutputStream()
         val pdfADokument = lagPdfADocument(byteArrayOutputStream)
         lagDokument(pdfADokument, feltMap)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -37,7 +37,7 @@ import no.nav.familie.pdf.pdf.PdfElementUtils.lagVerdiElement
 import no.nav.familie.pdf.pdf.PdfElementUtils.navLogoBilde
 import no.nav.familie.pdf.pdf.TabellUtils.håndterTabellBasertPåVisningsvariant
 import no.nav.familie.pdf.pdf.domain.FeltMap
-import no.nav.familie.pdf.pdf.domain.VerdilisteItem
+import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 import no.nav.familie.pdf.pdf.domain.VisningsVariant
 
 object PdfUtils {
@@ -147,7 +147,7 @@ object PdfUtils {
     }
 
     private fun lagSeksjon(
-        element: VerdilisteItem,
+        element: VerdilisteElement,
         navigeringDestinasjon: String,
     ): Div =
         Div().apply {
@@ -168,7 +168,7 @@ object PdfUtils {
 
     private fun håndterVisningsvariant(
         visningsVariant: String,
-        verdiliste: List<VerdilisteItem>,
+        verdiliste: List<VerdilisteElement>,
         seksjon: Div,
     ) {
         when (visningsVariant) {
@@ -187,7 +187,7 @@ object PdfUtils {
     }
 
     private fun håndterVedlegg(
-        verdiListe: List<VerdilisteItem>,
+        verdiListe: List<VerdilisteElement>,
         seksjon: Div,
     ) {
         verdiListe.forEach { vedlegg ->
@@ -201,7 +201,7 @@ object PdfUtils {
     }
 
     private fun håndterRekursivVerdiliste(
-        verdiliste: List<VerdilisteItem>,
+        verdiliste: List<VerdilisteElement>,
         seksjon: Div,
         rekursjonsDybde: Int = 1,
     ) {

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -206,19 +206,18 @@ object PdfUtils {
         rekursjonsDybde: Int = 1,
     ) {
         verdiliste.forEach { element ->
-            val verdilisteBarn = element.verdiliste
             val marginVenstre = 15f * rekursjonsDybde
             Div().apply {
                 isKeepTogether = true
                 if (element.visningsVariant != null) {
                     håndterVisningsvariant(
                         element.visningsVariant,
-                        verdilisteBarn ?: emptyList(),
+                        element.verdiliste ?: emptyList(),
                         seksjon,
                     )
-                } else if (verdilisteBarn != null && verdilisteBarn.isNotEmpty()) {
+                } else if (element.verdiliste != null && element.verdiliste.isNotEmpty()) {
                     seksjon.add(lagOverskriftH3(element.label).apply { setMarginLeft(marginVenstre) })
-                    håndterRekursivVerdiliste(verdilisteBarn, seksjon, rekursjonsDybde + 1)
+                    håndterRekursivVerdiliste(element.verdiliste, seksjon, rekursjonsDybde + 1)
                 } else if (element.verdi != null) {
                     seksjon.add(lagVerdiElement(element).apply { setMarginLeft(marginVenstre) })
                 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
@@ -8,10 +8,11 @@ import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Table
 import com.itextpdf.layout.properties.UnitValue
+import no.nav.familie.pdf.pdf.domain.VerdilisteItem
 
 object TabellUtils {
     fun lagTabell(
-        tabellData: List<*>,
+        tabellData: List<VerdilisteItem>,
         caption: String,
     ): Table {
         val tabell =
@@ -40,13 +41,13 @@ object TabellUtils {
     }
 
     private fun lagListeMedAlleElementer(
-        elementer: List<*>,
+        elementer: List<VerdilisteItem>,
         strengManSkalSplitteTabellPå: String,
-    ): List<List<*>> {
-        val listeMedAlleElementer = mutableListOf<List<*>>()
-        var nåværendeElement = mutableListOf<Map<*, *>>()
-        elementer.filterIsInstance<Map<*, *>>().forEachIndexed { index, item ->
-            if (item["label"].toString() == strengManSkalSplitteTabellPå && index != 0) {
+    ): List<List<VerdilisteItem>> {
+        val listeMedAlleElementer = mutableListOf<List<VerdilisteItem>>()
+        var nåværendeElement = mutableListOf<VerdilisteItem>()
+        elementer.forEachIndexed { index, item ->
+            if (item.label == strengManSkalSplitteTabellPå && index != 0) {
                 listeMedAlleElementer.add(nåværendeElement)
                 nåværendeElement = mutableListOf()
             }
@@ -57,20 +58,20 @@ object TabellUtils {
     }
 
     private fun lagTabellRekursivt(
-        tabellData: List<*>,
+        tabellData: List<VerdilisteItem>,
         tabell: Table,
     ) {
-        tabellData.filterIsInstance<Map<*, *>>().forEach { item ->
-            val label = item["label"].toString()
-            val value = item["verdi"]?.toString() ?: ""
+        tabellData.forEach { item ->
+            val label = item.label
+            val value = item.verdi ?: ""
             when {
-                item["verdi"] != null -> {
+                item.verdi != null -> {
                     tabell.addCell(lagTabellInformasjonscelle(label, erUthevet = true))
                     tabell.addCell(lagTabellInformasjonscelle(value.ifEmpty { " " }, false))
                 }
 
-                item["verdiliste"] != null -> {
-                    lagTabellRekursivt(item["verdiliste"] as List<*>, tabell)
+                item.verdiliste != null -> {
+                    lagTabellRekursivt(item.verdiliste, tabell)
                 }
             }
         }
@@ -111,7 +112,7 @@ object TabellUtils {
             }
 
     fun håndterTabellBasertPåVisningsvariant(
-        verdiliste: List<*>,
+        verdiliste: List<VerdilisteItem>,
         strengManSkalSplitteTabellPå: String,
         prefiks: String,
         seksjon: Div,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
@@ -8,11 +8,11 @@ import com.itextpdf.layout.element.Div
 import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Table
 import com.itextpdf.layout.properties.UnitValue
-import no.nav.familie.pdf.pdf.domain.VerdilisteItem
+import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 
 object TabellUtils {
     fun lagTabell(
-        tabellData: List<VerdilisteItem>,
+        tabellData: List<VerdilisteElement>,
         caption: String,
     ): Table {
         val tabell =
@@ -41,11 +41,11 @@ object TabellUtils {
     }
 
     private fun lagListeMedAlleElementer(
-        elementer: List<VerdilisteItem>,
+        elementer: List<VerdilisteElement>,
         strengManSkalSplitteTabellPå: String,
-    ): List<List<VerdilisteItem>> {
-        val listeMedAlleElementer = mutableListOf<List<VerdilisteItem>>()
-        var nåværendeElement = mutableListOf<VerdilisteItem>()
+    ): List<List<VerdilisteElement>> {
+        val listeMedAlleElementer = mutableListOf<List<VerdilisteElement>>()
+        var nåværendeElement = mutableListOf<VerdilisteElement>()
         elementer.forEachIndexed { index, item ->
             if (item.label == strengManSkalSplitteTabellPå && index != 0) {
                 listeMedAlleElementer.add(nåværendeElement)
@@ -58,7 +58,7 @@ object TabellUtils {
     }
 
     private fun lagTabellRekursivt(
-        tabellData: List<VerdilisteItem>,
+        tabellData: List<VerdilisteElement>,
         tabell: Table,
     ) {
         tabellData.forEach { item ->
@@ -112,7 +112,7 @@ object TabellUtils {
             }
 
     fun håndterTabellBasertPåVisningsvariant(
-        verdiliste: List<VerdilisteItem>,
+        verdiliste: List<VerdilisteElement>,
         strengManSkalSplitteTabellPå: String,
         prefiks: String,
         seksjon: Div,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TestPdfController.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TestPdfController.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.pdf.pdf
 
+import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.familie.pdf.pdf.domain.PdfMedStandarder
 import no.nav.security.token.support.core.api.Unprotected
 import org.springframework.context.annotation.Profile
@@ -25,6 +26,6 @@ class TestPdfController {
     @CrossOrigin(origins = ["http://localhost:5173"])
     @PostMapping("/pdf-med-standarder")
     fun opprettPdfMedValidering(
-        @RequestBody søknad: Map<String, Any>,
+        @RequestBody søknad: FeltMap,
     ): PdfMedStandarder = testPdfService.opprettPdfMedStandarder(søknad)
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TestPdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TestPdfService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.pdf.pdf
 
 import no.nav.familie.pdf.pdf.JsonLeser.lesSøknadJson
+import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.familie.pdf.pdf.domain.PdfMedStandarder
 import no.nav.familie.pdf.pdf.domain.PdfStandard
 import no.nav.familie.pdf.pdf.domain.Standard
@@ -13,7 +14,7 @@ class TestPdfService(
         return opprettPdfMedStandarder(feltMap)
     }
 
-    fun opprettPdfMedStandarder(feltMap: Map<String, Any>): PdfMedStandarder {
+    fun opprettPdfMedStandarder(feltMap: FeltMap): PdfMedStandarder {
         val pdf = pdfService.opprettPdf(feltMap)
         val pdfMedStandarder =
             PdfMedStandarder(

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/UtilsMetaData.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/UtilsMetaData.kt
@@ -6,6 +6,7 @@ import com.itextpdf.kernel.pdf.PdfViewerPreferences
 import com.itextpdf.kernel.xmp.XMPMeta
 import com.itextpdf.kernel.xmp.XMPMetaFactory
 import com.itextpdf.pdfa.PdfADocument
+import no.nav.familie.pdf.pdf.domain.FeltMap
 
 /**
  * Metadata settes på to måter for ulike behov:
@@ -15,10 +16,10 @@ import com.itextpdf.pdfa.PdfADocument
 object UtilsMetaData {
     fun leggtilMetaData(
         pdfADokument: PdfADocument,
-        feltMap: Map<String, Any>,
+        feltMap: FeltMap,
     ) {
         val skaperAvPdf = "navikt/familie-pdf"
-        val tittel = feltMap["label"].toString()
+        val tittel = feltMap.label
 
         pdfADokument.documentInfo.apply {
             this.title = tittel

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -1,0 +1,14 @@
+package no.nav.familie.pdf.pdf.domain
+
+data class FeltMap(
+    val label: String,
+    val verdiliste: List<VerdilisteItem>,
+)
+
+data class VerdilisteItem(
+    val label: String,
+    val verdi: String? = null,
+    val visningsVariant: String? = null,
+    val verdiliste: List<VerdilisteItem>? = null,
+    val alternativer: String? = null,
+)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -2,13 +2,13 @@ package no.nav.familie.pdf.pdf.domain
 
 data class FeltMap(
     val label: String,
-    val verdiliste: List<VerdilisteItem>,
+    val verdiliste: List<VerdilisteElement>,
 )
 
-data class VerdilisteItem(
+data class VerdilisteElement(
     val label: String,
     val verdi: String? = null,
     val visningsVariant: String? = null,
-    val verdiliste: List<VerdilisteItem>? = null,
+    val verdiliste: List<VerdilisteElement>? = null,
     val alternativer: String? = null,
 )

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -1,7 +1,11 @@
 package no.nav.familie.pdf.pdf.domain
 
+import jakarta.validation.constraints.NotNull
+
 data class FeltMap(
+    @field:NotNull(message = "Label kan ikke være null")
     val label: String,
+    @field:NotNull(message = "Verdiliste kan ikke være null")
     val verdiliste: List<VerdilisteElement>,
 )
 

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/JsonLeserTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/JsonLeserTest.kt
@@ -10,11 +10,11 @@ class JsonLeserTest {
         // Act
         val resultat = lesSøknadJson()
         // Assert
-        assertEquals("Søknad om overgangsstønad (NAV 15-00.01)", resultat["label"])
-        val verdiliste = resultat["verdiliste"] as List<Map<String, Any>>
-        assertEquals("Innsendingsdetaljer", verdiliste[0]["label"])
-        val innsendingsdetaljer = verdiliste[0]["verdiliste"] as List<Map<String, Any>>
-        assertEquals("Dato mottatt", innsendingsdetaljer[0]["label"])
-        assertEquals("09.10.2024 09:59:35", innsendingsdetaljer[0]["verdi"])
+        assertEquals("Søknad om overgangsstønad (NAV 15-00.01)", resultat.label)
+        val verdiliste = resultat.verdiliste
+        assertEquals("Innsendingsdetaljer", verdiliste[0].label)
+        val innsendingsdetaljer = verdiliste[0].verdiliste
+        assertEquals("Dato mottatt", innsendingsdetaljer?.get(0)?.label)
+        assertEquals("09.10.2024 09:59:35", innsendingsdetaljer?.get(0)?.verdi)
     }
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -12,10 +12,9 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedForskjelligLabelIVe
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomAdresse
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagNullInnhold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
 import no.nav.familie.pdf.pdf.PdfService
-import org.junit.jupiter.api.Assertions.assertThrows
+import no.nav.familie.pdf.pdf.domain.FeltMap
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -36,21 +35,21 @@ class PdfServiceTest {
             )
 
         @JvmStatic
-        fun innholdsfortegnelseMedEnOgToSider(): Stream<Map<String, Any>> =
+        fun innholdsfortegnelseMedEnOgToSider(): Stream<FeltMap> =
             Stream.of(
                 lagMedVerdiliste(),
                 lagToSiderInnholdsfortegnelse(),
             )
 
         @JvmStatic
-        fun tomAdresse(): Stream<Map<String, Any>> =
+        fun tomAdresse(): Stream<FeltMap> =
             Stream.of(
                 lagAdresseMedBareLinjeskift(),
                 lagMedTomAdresse(),
             )
 
         @JvmStatic
-        fun flereArbeidsforhold(): Stream<Map<String, Any>> =
+        fun flereArbeidsforhold(): Stream<FeltMap> =
             Stream.of(
                 lagMedFlereArbeidsforhold(),
             )
@@ -87,16 +86,6 @@ class PdfServiceTest {
     }
 
     @Test
-    fun `Pdf kaster exception hvis label eller verdiliste er null`() {
-        // Arrange
-        val feltMap = lagNullInnhold()
-        // Act & Assert
-        assertThrows(IllegalArgumentException::class.java) {
-            pdfOppretterService.opprettPdf(feltMap as Map<String, Any>)
-        }
-    }
-
-    @Test
     fun `Pdf har riktig sideantall for nåværende side`() {
         // Arrange
         val feltMap = lagMedVerdiliste()
@@ -113,7 +102,7 @@ class PdfServiceTest {
 
     @ParameterizedTest
     @MethodSource("innholdsfortegnelseMedEnOgToSider")
-    fun `Pdf legger forside med innholdsfortegnelse først`(feltMap: Map<String, Any>) {
+    fun `Pdf legger forside med innholdsfortegnelse først`(feltMap: FeltMap) {
         // Act
         val pdfDoc = opprettPdf(feltMap)
         val førsteSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
@@ -124,7 +113,7 @@ class PdfServiceTest {
 
     @ParameterizedTest
     @MethodSource("flereArbeidsforhold")
-    fun `Pdf lager tabell dersom du har flere arbeidsforhold`(feltMap: Map<String, Any>) {
+    fun `Pdf lager tabell dersom du har flere arbeidsforhold`(feltMap: FeltMap) {
         // Act
         val pdfDoc = opprettPdf(feltMap)
         val tekstIPdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
@@ -137,7 +126,7 @@ class PdfServiceTest {
     @ParameterizedTest
     @MethodSource("innholdsfortegnelseMedEnOgToSiderOgForventetSide")
     fun `Pdf har riktig sideantall i innholdsfortegnelsen`(
-        feltMap: Map<String, Any>,
+        feltMap: FeltMap,
         forventetSide: Int,
     ) {
         // Act
@@ -158,7 +147,7 @@ class PdfServiceTest {
 
     @ParameterizedTest
     @MethodSource("tomAdresse")
-    fun `Pdf med innhold i Adresse blir renset for tom og flere linjeskift`(feltMap: Map<String, Any>) {
+    fun `Pdf med innhold i Adresse blir renset for tom og flere linjeskift`(feltMap: FeltMap) {
         // Act
         val pdfDoc = opprettPdf(feltMap)
         val andreSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
@@ -178,7 +167,7 @@ class PdfServiceTest {
         assertTrue(andreSideTekst.contains("Adresse 12 \n0999 Oslo"))
     }
 
-    private fun opprettPdf(feltMap: Map<String, Any>): PdfADocument {
+    private fun opprettPdf(feltMap: FeltMap): PdfADocument {
         val result = pdfOppretterService.opprettPdf(feltMap)
         val pdfReader = PdfReader(ByteArrayInputStream(result))
         val pdfWriter = PdfWriter(ByteArrayOutputStream())

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -1,101 +1,119 @@
 package no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils
 
-fun lagMedTomVerdiliste(): Map<String, Any> = mapOf("label" to "Søknad om overgangsstønad", "verdiliste" to emptyList<Any>())
+import no.nav.familie.pdf.pdf.domain.FeltMap
+import no.nav.familie.pdf.pdf.domain.VerdilisteItem
+import no.nav.familie.pdf.pdf.domain.VisningsVariant
 
-fun lagMedVerdiliste(): Map<String, Any> =
-    mapOf(
-        "label" to "Søknad om overgangsstønad",
-        "verdiliste" to
+private val søknadsTittel = "Søknad om overgangsstønad (NAV 15-00.01)"
+
+fun lagMedTomVerdiliste(): FeltMap = FeltMap(søknadsTittel, emptyList())
+
+fun lagMedVerdiliste(): FeltMap =
+    FeltMap(
+        label = "Søknad om overgangsstønad",
+        verdiliste =
             listOf(
-                mapOf(
-                    "label" to "Innsendingsdetaljer",
-                    "verdiliste" to
+                VerdilisteItem(
+                    label = "Innsendingsdetaljer",
+                    verdiliste =
                         listOf(
-                            mapOf("label" to "Navn", "verdi" to "Kåre"),
-                            mapOf("label" to "Født", "verdi" to "Ja"),
+                            VerdilisteItem(label = "Navn", verdi = "Kåre"),
+                            VerdilisteItem(label = "Født", verdi = "Ja"),
                         ),
                 ),
             ),
     )
 
-fun lagMedForskjelligLabelIVerdiliste(): Map<String, Any> =
-    mapOf(
-        "label" to "Søknad om overgangsstønad",
-        "verdiliste" to
+fun lagMedForskjelligLabelIVerdiliste(): FeltMap =
+    FeltMap(
+        label = "Søknad om overgangsstønad",
+        verdiliste =
             listOf(
-                mapOf("label" to "Barna dine", "verdiliste" to emptyList<Any>()),
-                mapOf(
-                    "label" to "Innsendingsdetaljer",
-                    "verdiliste" to listOf(mapOf("label" to "Navn", "verdi" to "Bjarne")),
+                VerdilisteItem(
+                    label = "Barna dine",
+                    verdiliste = emptyList(),
+                ),
+                VerdilisteItem(
+                    label = "Innsendingsdetaljer",
+                    verdiliste =
+                        listOf(
+                            VerdilisteItem(label = "Navn", verdi = "Bjarne"),
+                        ),
                 ),
             ),
     )
 
-fun lagNullInnhold(): Map<String, Any?> = mapOf("label" to null, "verdiliste" to null)
-
-fun lagMedTomAdresse(): Map<String, Any> =
-    mapOf(
-        "label" to "Søknad om overgangsstønad",
-        "verdiliste" to
+fun lagMedTomAdresse(): FeltMap =
+    FeltMap(
+        label = "Søknad om overgangsstønad",
+        verdiliste =
             listOf(
-                mapOf(
-                    "label" to "Søker",
-                    "verdiliste" to listOf(mapOf("label" to "Adresse", "verdi" to "")),
+                VerdilisteItem(
+                    label = "Søker",
+                    verdiliste =
+                        listOf(
+                            VerdilisteItem(label = "Adresse", verdi = ""),
+                        ),
                 ),
             ),
     )
 
-fun lagAdresseMedBareLinjeskift(): Map<String, Any> =
-    mapOf(
-        "label" to "Søknad om overgangsstønad",
-        "verdiliste" to
+fun lagAdresseMedBareLinjeskift(): FeltMap =
+    FeltMap(
+        label = "Søknad om overgangsstønad",
+        verdiliste =
             listOf(
-                mapOf(
-                    "label" to "Søker",
-                    "verdiliste" to listOf(mapOf("label" to "Adresse", "verdi" to "\n\n\n\n")),
+                VerdilisteItem(
+                    label = "Søker",
+                    verdiliste =
+                        listOf(
+                            VerdilisteItem(label = "Adresse", verdi = "\n\n\n\n"),
+                        ),
                 ),
             ),
     )
 
-fun lagAdresseMedFlereLinjeskift(): Map<String, Any> =
-    mapOf(
-        "label" to "Søknad om overgangsstønad",
-        "verdiliste" to
+fun lagAdresseMedFlereLinjeskift(): FeltMap =
+    FeltMap(
+        label = "Søknad om overgangsstønad",
+        verdiliste =
             listOf(
-                mapOf(
-                    "label" to "Søker",
-                    "verdiliste" to listOf(mapOf("label" to "Adresse", "verdi" to "Adresse 12\n\n\n\n0999 Oslo")),
+                VerdilisteItem(
+                    label = "Søker",
+                    verdiliste =
+                        listOf(
+                            VerdilisteItem(label = "Adresse", verdi = "Adresse 12\n\n\n\n0999 Oslo"),
+                        ),
                 ),
             ),
     )
 
-fun lagToSiderInnholdsfortegnelse(): Map<String, Any> =
-    mapOf(
-        "label" to "Søknad om overgangsstønad (NAV 15-00.01)",
-        "verdiliste" to lagGjentattInnhold(48),
-    )
+fun lagToSiderInnholdsfortegnelse(): FeltMap = FeltMap(søknadsTittel, lagGjentattInnhold(48))
 
-private fun lagGjentattInnhold(antallGanger: Int): List<Map<String, Any>> =
+private fun lagGjentattInnhold(antallGanger: Int): List<VerdilisteItem> =
     List(antallGanger) { indeks ->
-        mapOf(
-            "label" to "Innsendingsdetaljer${if (indeks > 0) indeks + 1 else ""}",
-            "verdiliste" to emptyList<Any>(),
+        VerdilisteItem(
+            label = "Innsendingsdetaljer${if (indeks > 0) indeks + 1 else ""}",
+            verdiliste = emptyList(),
         )
     }
 
-fun lagMedFlereArbeidsforhold(): Map<String, Any> =
-    mapOf(
-        "label" to "Arbeid, utdanning og andre aktiviteter",
-        "verdiliste" to
+fun lagMedFlereArbeidsforhold(): FeltMap =
+    FeltMap(
+        label = "Arbeid, utdanning og andre aktiviteter",
+        verdiliste =
             listOf(
-                mapOf("label" to "Hvordan er situasjonen din?", "verdi" to "Jeg er arbeidstaker (og/eller lønnsmottaker som frilanser)"),
-                mapOf(
-                    "label" to "Om arbeidsforholdet ditt",
-                    "visningsVariant" to "TABELL_ARBEIDSFORHOLD",
-                    "verdiliste" to
+                VerdilisteItem(
+                    label = "Hvordan er situasjonen din?",
+                    verdi = "Jeg er arbeidstaker (og/eller lønnsmottaker som frilanser)",
+                ),
+                VerdilisteItem(
+                    label = "Om arbeidsforholdet ditt",
+                    visningsVariant = VisningsVariant.TABELL_ARBEIDSFORHOLD.toString(),
+                    verdiliste =
                         listOf(
-                            mapOf("label" to "Navn på arbeidssted", "verdi" to "Norge.as"),
-                            mapOf("label" to "Navn på arbeidssted", "verdi" to "Sverige.as"),
+                            VerdilisteItem(label = "Navn på arbeidssted", verdi = "Norge.as"),
+                            VerdilisteItem(label = "Navn på arbeidssted", verdi = "Sverige.as"),
                         ),
                 ),
             ),

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils
 
 import no.nav.familie.pdf.pdf.domain.FeltMap
-import no.nav.familie.pdf.pdf.domain.VerdilisteItem
+import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 import no.nav.familie.pdf.pdf.domain.VisningsVariant
 
 private val søknadsTittel = "Søknad om overgangsstønad (NAV 15-00.01)"
@@ -10,15 +10,15 @@ fun lagMedTomVerdiliste(): FeltMap = FeltMap(søknadsTittel, emptyList())
 
 fun lagMedVerdiliste(): FeltMap =
     FeltMap(
-        label = "Søknad om overgangsstønad",
+        label = søknadsTittel,
         verdiliste =
             listOf(
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Innsendingsdetaljer",
                     verdiliste =
                         listOf(
-                            VerdilisteItem(label = "Navn", verdi = "Kåre"),
-                            VerdilisteItem(label = "Født", verdi = "Ja"),
+                            VerdilisteElement(label = "Navn", verdi = "Kåre"),
+                            VerdilisteElement(label = "Født", verdi = "Ja"),
                         ),
                 ),
             ),
@@ -26,18 +26,18 @@ fun lagMedVerdiliste(): FeltMap =
 
 fun lagMedForskjelligLabelIVerdiliste(): FeltMap =
     FeltMap(
-        label = "Søknad om overgangsstønad",
+        label = søknadsTittel,
         verdiliste =
             listOf(
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Barna dine",
                     verdiliste = emptyList(),
                 ),
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Innsendingsdetaljer",
                     verdiliste =
                         listOf(
-                            VerdilisteItem(label = "Navn", verdi = "Bjarne"),
+                            VerdilisteElement(label = "Navn", verdi = "Bjarne"),
                         ),
                 ),
             ),
@@ -45,14 +45,14 @@ fun lagMedForskjelligLabelIVerdiliste(): FeltMap =
 
 fun lagMedTomAdresse(): FeltMap =
     FeltMap(
-        label = "Søknad om overgangsstønad",
+        label = søknadsTittel,
         verdiliste =
             listOf(
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Søker",
                     verdiliste =
                         listOf(
-                            VerdilisteItem(label = "Adresse", verdi = ""),
+                            VerdilisteElement(label = "Adresse", verdi = ""),
                         ),
                 ),
             ),
@@ -60,14 +60,14 @@ fun lagMedTomAdresse(): FeltMap =
 
 fun lagAdresseMedBareLinjeskift(): FeltMap =
     FeltMap(
-        label = "Søknad om overgangsstønad",
+        label = søknadsTittel,
         verdiliste =
             listOf(
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Søker",
                     verdiliste =
                         listOf(
-                            VerdilisteItem(label = "Adresse", verdi = "\n\n\n\n"),
+                            VerdilisteElement(label = "Adresse", verdi = "\n\n\n\n"),
                         ),
                 ),
             ),
@@ -75,14 +75,14 @@ fun lagAdresseMedBareLinjeskift(): FeltMap =
 
 fun lagAdresseMedFlereLinjeskift(): FeltMap =
     FeltMap(
-        label = "Søknad om overgangsstønad",
+        label = søknadsTittel,
         verdiliste =
             listOf(
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Søker",
                     verdiliste =
                         listOf(
-                            VerdilisteItem(label = "Adresse", verdi = "Adresse 12\n\n\n\n0999 Oslo"),
+                            VerdilisteElement(label = "Adresse", verdi = "Adresse 12\n\n\n\n0999 Oslo"),
                         ),
                 ),
             ),
@@ -90,9 +90,9 @@ fun lagAdresseMedFlereLinjeskift(): FeltMap =
 
 fun lagToSiderInnholdsfortegnelse(): FeltMap = FeltMap(søknadsTittel, lagGjentattInnhold(48))
 
-private fun lagGjentattInnhold(antallGanger: Int): List<VerdilisteItem> =
+private fun lagGjentattInnhold(antallGanger: Int): List<VerdilisteElement> =
     List(antallGanger) { indeks ->
-        VerdilisteItem(
+        VerdilisteElement(
             label = "Innsendingsdetaljer${if (indeks > 0) indeks + 1 else ""}",
             verdiliste = emptyList(),
         )
@@ -103,17 +103,17 @@ fun lagMedFlereArbeidsforhold(): FeltMap =
         label = "Arbeid, utdanning og andre aktiviteter",
         verdiliste =
             listOf(
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Hvordan er situasjonen din?",
                     verdi = "Jeg er arbeidstaker (og/eller lønnsmottaker som frilanser)",
                 ),
-                VerdilisteItem(
+                VerdilisteElement(
                     label = "Om arbeidsforholdet ditt",
                     visningsVariant = VisningsVariant.TABELL_ARBEIDSFORHOLD.toString(),
                     verdiliste =
                         listOf(
-                            VerdilisteItem(label = "Navn på arbeidssted", verdi = "Norge.as"),
-                            VerdilisteItem(label = "Navn på arbeidssted", verdi = "Sverige.as"),
+                            VerdilisteElement(label = "Navn på arbeidssted", verdi = "Norge.as"),
+                            VerdilisteElement(label = "Navn på arbeidssted", verdi = "Sverige.as"),
                         ),
                 ),
             ),


### PR DESCRIPTION
Nå slipper vi å caste alt mulig og vi slipper å bruke `map`, `any` og `*`.  Så synes jeg det er enklere å lese og forstå koden nå også.
Testet lokalt at pdf-en fungerer som normalt, med blant annet visningsvarianter.

