### PR TITLE
Fjerner unødvendig null-check

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -1,11 +1,7 @@
 package no.nav.familie.pdf.pdf.domain
 
-import jakarta.validation.constraints.NotNull
-
 data class FeltMap(
-    @field:NotNull(message = "Label kan ikke være null")
     val label: String,
-    @field:NotNull(message = "Verdiliste kan ikke være null")
     val verdiliste: List<VerdilisteElement>,
 )
 


### PR DESCRIPTION
Når det ikke er nullable bak typen kan den heller ikke være null så denne annotasjonen var unødvendig