### PR TITLE
mindre skriftstørrlese på h3

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -64,7 +64,7 @@ object PdfElementUtils {
 
     fun lagOverskriftH2(tekst: String): Paragraph = lagOverskrift(tekst, 20f, StandardRoles.H2)
 
-    fun lagOverskriftH3(tekst: String): Paragraph = lagOverskrift(tekst, 16f, StandardRoles.H3)
+    fun lagOverskriftH3(tekst: String): Paragraph = lagOverskrift(tekst, 14f, StandardRoles.H3)
 
     private fun lagOverskrift(
         tekst: String,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -62,9 +62,14 @@ object PdfElementUtils {
 
     fun lagOverskriftH1(tekst: String): Paragraph = lagOverskrift(tekst, 24f, StandardRoles.H1)
 
-    fun lagOverskriftH2(tekst: String): Paragraph = lagOverskrift(tekst, 20f, StandardRoles.H2)
+    fun lagOverskriftH2(tekst: String): Paragraph = lagOverskrift(tekst, 18f, StandardRoles.H2)
 
-    fun lagOverskriftH3(tekst: String): Paragraph = lagOverskrift(tekst, 14f, StandardRoles.H3)
+    fun lagOverskriftH3(tekst: String): Paragraph =
+        lagOverskrift(
+            tekst,
+            14f,
+            StandardRoles.H3,
+        )
 
     private fun lagOverskrift(
         tekst: String,


### PR DESCRIPTION
Mindre skiftstørrelse på h3. 

Endringer:
- 16f ->14f på h3
**Før:**
<img width="777" alt="image" src="https://github.com/user-attachments/assets/70c53973-25e4-4efc-9a26-a88d4999a8fa" />

**Etter:**
<img width="787" alt="image" src="https://github.com/user-attachments/assets/0ef28fb8-4ea7-4e0e-a918-d92af71857a1" />


AKSEL:
[spire-nav (13).pdf](https://github.com/user-attachments/files/18320903/spire-nav.13.pdf)


