### PR TITLE
Håndtering av manglende søknadstype

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -230,15 +230,17 @@ object PdfUtils {
         innholdsfortegnelseOppføringer: List<InnholdsfortegnelseOppføringer>,
     ) {
         val tittel = overskrift.substringBefore(" (")
-        val søknadstype = overskrift.substringAfter(" (").trimEnd(')')
+        val søknadstype = overskrift.substringAfter(" (", "").trimEnd(')')
         add(AreaBreak(AreaBreakType.NEXT_PAGE))
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        add(
-            Paragraph(søknadstype).apply {
-                setMarginTop(-10f)
-            },
-        )
+        if (søknadstype.isNotEmpty()) {
+            add(
+                Paragraph(søknadstype).apply {
+                    setMarginTop(-10f)
+                }
+            )
+        }
         add(lagOverskriftH2("Innholdsfortegnelse"))
         add(lagInnholdsfortegnelse(innholdsfortegnelseOppføringer))
     }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -53,6 +53,18 @@ class PdfServiceTest {
             Stream.of(
                 lagMedFlereArbeidsforhold(),
             )
+
+        @JvmStatic
+        fun soknadstypeIOverskrift(): Stream<FeltMap> =
+            Stream.of(
+                lagMedVerdiliste(),
+            )
+
+        @JvmStatic
+        fun pdfUtenSoknadstypeIOverskrift(): Stream<FeltMap> =
+            Stream.of(
+                lagMedFlereArbeidsforhold(),
+            )
     }
 
     @Test
@@ -124,6 +136,30 @@ class PdfServiceTest {
     }
 
     @ParameterizedTest
+    @MethodSource("soknadstypeIOverskrift")
+    fun `Pdf har soknadstype i overskrift`(feltMap: FeltMap) {
+        // Act
+        val pdfDoc = opprettPdf(feltMap)
+        val førsteSidePdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
+
+        // Assert
+        assertTrue(førsteSidePdf.contains("Søknad om overgangsstønad"))
+        assertTrue(førsteSidePdf.contains("NAV 15-00.01"))
+    }
+
+    @ParameterizedTest
+    @MethodSource("pdfUtenSoknadstypeIOverskrift")
+    fun `Overskrift dukker ikke opp som soknadstype`(feltMap: FeltMap) {
+        // Act
+        val pdfDoc = opprettPdf(feltMap)
+        val førsteSidePdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
+
+        // Assert
+        // Assert
+        val antallForekomster = Regex("Arbeid, utdanning og andre aktiviteter").findAll(førsteSidePdf).count()
+        assertTrue(1 == antallForekomster)
+    }
+    @ParameterizedTest
     @MethodSource("innholdsfortegnelseMedEnOgToSiderOgForventetSide")
     fun `Pdf har riktig sideantall i innholdsfortegnelsen`(
         feltMap: FeltMap,
@@ -131,7 +167,7 @@ class PdfServiceTest {
     ) {
         // Act
         val pdfDoc = opprettPdf(feltMap)
-        val firstPageText = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
+        val førsteSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
 
         // Assert
         val forventetInnholdsfortegnelse =
@@ -139,9 +175,9 @@ class PdfServiceTest {
                 "Innsendingsdetaljer" to forventetSide,
             )
         for ((label, forventetSide) in forventetInnholdsfortegnelse) {
-            assertTrue(firstPageText.contains("$label $forventetSide"))
-            val actualPageText = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(forventetSide))
-            assertTrue(actualPageText.contains(label))
+            assertTrue(førsteSideTekst.contains("$label $forventetSide"))
+            val faktiskSideTekst = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(forventetSide))
+            assertTrue(faktiskSideTekst.contains(label))
         }
     }
 

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegn
 import no.nav.familie.pdf.pdf.PdfService
 import no.nav.familie.pdf.pdf.domain.FeltMap
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -47,7 +48,6 @@ class PdfServiceTest {
                 lagAdresseMedBareLinjeskift(),
                 lagMedTomAdresse(),
             )
-
         @JvmStatic
         fun flereArbeidsforhold(): Stream<FeltMap> =
             Stream.of(

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -101,7 +101,7 @@ class PdfServiceTest {
     }
 
     @Test
-    fun `Pdf har soknadstype i overskrift`(){
+    fun `Pdf har søknadstype i overskrift`(){
         // Arrange
         val feltMap = lagMedVerdiliste()
 
@@ -115,7 +115,7 @@ class PdfServiceTest {
     }
 
     @Test
-    fun `Overskrift dukker ikke opp som soknadstype`() {
+    fun `Overskrift dukker ikke opp som søknadstype`() {
         // Arrange
         val feltMap = lagMedFlereArbeidsforhold()
 

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -118,3 +118,4 @@ fun lagMedFlereArbeidsforhold(): FeltMap =
                 ),
             ),
     )
+

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -118,4 +118,3 @@ fun lagMedFlereArbeidsforhold(): FeltMap =
                 ),
             ),
     )
-


### PR DESCRIPTION
Beskrivelse:
Forhindrer at hele overskriften tolkes som søknadstype hvis " (" mangler. Returnerer nå en tom streng ("") i stedet.

Endringer:

substringAfter(" (", "") gir tom streng ved fravær av søknadstype.
Viser "Søknadstype ikke spesifisert" i PDF hvis søknadstype mangler.
Hvorfor:

Gir tydeligere og mer robust håndtering av manglende søknadstype.
 
Bug: 
Tittel vises to ganger hvis man ikke har søknadstype/() i tittelen

<img width="446" alt="Screenshot 2025-01-02 at 14 53 18" src="https://github.com/user-attachments/assets/e07244d8-20de-42ad-9445-081f60ec8d9b" />
<img width="449" alt="Screenshot 2025-01-02 at 14 53 41" src="https://github.com/user-attachments/assets/5181cddf-4f20-453c-ac98-fcaf8d597923" />
