### PR TITLE
Mørk bakgrunnsfarge tabell

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
@@ -37,7 +37,7 @@ object TabellUtils {
 
         tabell.addCell(lagTabellOverskriftscelle("Spørsmål"))
         tabell.addCell(lagTabellOverskriftscelle("Svar", false))
-        lagTabellRekursivt(tabellData, tabell, MutableWrapper(false))
+        lagTabellRekursivt(tabellData, tabell)
         return tabell
     }
 
@@ -61,8 +61,10 @@ object TabellUtils {
     private fun lagTabellRekursivt(
         tabellData: List<VerdilisteElement>,
         tabell: Table,
-        mørkBakgrunn: MutableWrapper<Boolean>,
-    ) {
+        erMørkBakgrunn: Boolean = false,
+    ): Boolean {
+        var nåværendeBakgrunnErMørk = erMørkBakgrunn
+
         tabellData.forEach { item ->
             val label = item.label
             val value = item.verdi ?: ""
@@ -71,26 +73,23 @@ object TabellUtils {
                     val labelCelle = lagTabellInformasjonscelle(label, erUthevet = true)
                     val verdiCelle = lagTabellInformasjonscelle(value, false)
 
-                    if (mørkBakgrunn.value) {
+                    if (nåværendeBakgrunnErMørk) {
                         labelCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
                         verdiCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
                     }
                     tabell.addCell(labelCelle)
                     tabell.addCell(verdiCelle)
 
-                    mørkBakgrunn.value = !mørkBakgrunn.value
+                    nåværendeBakgrunnErMørk = !nåværendeBakgrunnErMørk
                 }
 
                 item.verdiliste != null -> {
-                    lagTabellRekursivt(item.verdiliste, tabell, mørkBakgrunn)
+                    nåværendeBakgrunnErMørk = lagTabellRekursivt(item.verdiliste, tabell, nåværendeBakgrunnErMørk)
                 }
             }
         }
+        return nåværendeBakgrunnErMørk
     }
-
-    data class MutableWrapper<T>(
-        var value: T,
-    )
 
     private fun lagTabellInformasjonscelle(
         tekst: String,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.pdf.pdf
 
+import com.itextpdf.kernel.colors.ColorConstants
 import com.itextpdf.kernel.colors.DeviceRgb
 import com.itextpdf.kernel.pdf.tagging.StandardRoles
 import com.itextpdf.layout.borders.Border
@@ -36,7 +37,7 @@ object TabellUtils {
 
         tabell.addCell(lagTabellOverskriftscelle("Spørsmål"))
         tabell.addCell(lagTabellOverskriftscelle("Svar", false))
-        lagTabellRekursivt(tabellData, tabell)
+        lagTabellRekursivt(tabellData, tabell, MutableWrapper(false))
         return tabell
     }
 
@@ -60,22 +61,36 @@ object TabellUtils {
     private fun lagTabellRekursivt(
         tabellData: List<VerdilisteElement>,
         tabell: Table,
+        mørkBakgrunn: MutableWrapper<Boolean>,
     ) {
         tabellData.forEach { item ->
             val label = item.label
             val value = item.verdi ?: ""
             when {
                 item.verdi != null -> {
-                    tabell.addCell(lagTabellInformasjonscelle(label, erUthevet = true))
-                    tabell.addCell(lagTabellInformasjonscelle(value.ifEmpty { " " }, false))
+                    val labelCelle = lagTabellInformasjonscelle(label, erUthevet = true)
+                    val verdiCelle = lagTabellInformasjonscelle(value, false)
+
+                    if (mørkBakgrunn.value) {
+                        labelCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
+                        verdiCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
+                    }
+                    tabell.addCell(labelCelle)
+                    tabell.addCell(verdiCelle)
+
+                    mørkBakgrunn.value = !mørkBakgrunn.value
                 }
 
                 item.verdiliste != null -> {
-                    lagTabellRekursivt(item.verdiliste, tabell)
+                    lagTabellRekursivt(item.verdiliste, tabell, mørkBakgrunn)
                 }
             }
         }
     }
+
+    data class MutableWrapper<T>(
+        var value: T,
+    )
 
     private fun lagTabellInformasjonscelle(
         tekst: String,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.pdf.pdf
 
-import com.itextpdf.kernel.colors.ColorConstants
 import com.itextpdf.kernel.colors.DeviceRgb
 import com.itextpdf.kernel.pdf.tagging.StandardRoles
 import com.itextpdf.layout.borders.Border
@@ -74,8 +73,8 @@ object TabellUtils {
                     val verdiCelle = lagTabellInformasjonscelle(value, false)
 
                     if (mørkBakgrunn) {
-                        labelCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
-                        verdiCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
+                        labelCelle.apply { setBackgroundColor(DeviceRgb(204, 225, 255)) }
+                        verdiCelle.apply { setBackgroundColor(DeviceRgb(204, 225, 255)) }
                     }
                     tabell.addCell(labelCelle)
                     tabell.addCell(verdiCelle)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/TabellUtils.kt
@@ -61,9 +61,9 @@ object TabellUtils {
     private fun lagTabellRekursivt(
         tabellData: List<VerdilisteElement>,
         tabell: Table,
-        erMørkBakgrunn: Boolean = false,
+        bakgrunnErMørk: Boolean = false,
     ): Boolean {
-        var nåværendeBakgrunnErMørk = erMørkBakgrunn
+        var mørkBakgrunn = bakgrunnErMørk
 
         tabellData.forEach { item ->
             val label = item.label
@@ -73,22 +73,22 @@ object TabellUtils {
                     val labelCelle = lagTabellInformasjonscelle(label, erUthevet = true)
                     val verdiCelle = lagTabellInformasjonscelle(value, false)
 
-                    if (nåværendeBakgrunnErMørk) {
+                    if (mørkBakgrunn) {
                         labelCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
                         verdiCelle.apply { setBackgroundColor(ColorConstants.LIGHT_GRAY) }
                     }
                     tabell.addCell(labelCelle)
                     tabell.addCell(verdiCelle)
 
-                    nåværendeBakgrunnErMørk = !nåværendeBakgrunnErMørk
+                    mørkBakgrunn = !mørkBakgrunn
                 }
 
                 item.verdiliste != null -> {
-                    nåværendeBakgrunnErMørk = lagTabellRekursivt(item.verdiliste, tabell, nåværendeBakgrunnErMørk)
+                    mørkBakgrunn = lagTabellRekursivt(item.verdiliste, tabell, mørkBakgrunn)
                 }
             }
         }
-        return nåværendeBakgrunnErMørk
+        return mørkBakgrunn
     }
 
     private fun lagTabellInformasjonscelle(


### PR DESCRIPTION
Endret slik at annenhver rad i tabellen har mørkere farge enn resterende halvpart, slik at det blir lettere å skille radene fra hverandre

![image](https://github.com/user-attachments/assets/a844ca71-8818-426b-8667-779dbd422b2b)
