### PR TITLE
mindre tekststorrelse

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -62,11 +62,11 @@ object PdfElementUtils {
             accessibilityProperties.role = StandardRoles.P
         }
 
-    fun lagOverskriftH1(tekst: String): Paragraph = lagOverskrift(tekst, 24f, StandardRoles.H1)
+    fun lagOverskriftH1(tekst: String): Paragraph = lagOverskrift(tekst, 20f, StandardRoles.H1)
 
-    fun lagOverskriftH2(tekst: String): Paragraph = lagOverskrift(tekst, 20f, StandardRoles.H2)
+    fun lagOverskriftH2(tekst: String): Paragraph = lagOverskrift(tekst, 16f, StandardRoles.H2)
 
-    fun lagOverskriftH3(tekst: String): Paragraph = lagOverskrift(tekst, 16f, StandardRoles.H3)
+    fun lagOverskriftH3(tekst: String): Paragraph = lagOverskrift(tekst, 14f, StandardRoles.H3)
 
     private fun lagOverskrift(
         tekst: String,


### PR DESCRIPTION
Mindre tekst størrelse på h1,h2,h3

**Før / Etter**

![image](https://github.com/user-attachments/assets/c03cd51a-5e20-4775-bb16-f26a3b5741d8)

![image](https://github.com/user-attachments/assets/58ef34ed-979d-47ad-ab5f-475cf06e149b)


Ny -  [spire-nav (20).pdf](https://github.com/user-attachments/files/18396681/spire-nav.20.pdf)
Gammel -  [spire-nav (19).pdf](https://github.com/user-attachments/files/18396682/spire-nav.19.pdf)
