### PR TITLE
Legg til oversettelser for nynorsk (nn) og engelsk (en)

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -15,6 +15,8 @@ import com.itextpdf.layout.element.Text
 import com.itextpdf.layout.properties.UnitValue
 import no.nav.familie.pdf.pdf.PdfUtils.FontStil
 import no.nav.familie.pdf.pdf.PdfUtils.settFont
+import no.nav.familie.pdf.pdf.domain.FeltMap
+import no.nav.familie.pdf.pdf.domain.Konfigurasjon
 import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 
 object PdfElementUtils {
@@ -135,8 +137,20 @@ object PdfElementUtils {
                 )
             }
         tabell.caption = captionDiv
-        tabell.addCell(lagTabellOverskriftscelle("Spørsmål"))
-        tabell.addCell(lagTabellOverskriftscelle("Svar", false))
+        val spørsmål: String =
+            when (brukSpråk()) {
+                "nn" -> "Spørsmål"
+                "en" -> "Questions"
+                else -> "Spørsmål"
+            }
+        val svar: String =
+            when (brukSpråk()) {
+                "nn" -> "Svar"
+                "en" -> "Answer"
+                else -> "Svar"
+            }
+        tabell.addCell(lagTabellOverskriftscelle(spørsmål))
+        tabell.addCell(lagTabellOverskriftscelle(svar, false))
         lagTabellRekursivt(tabellData.verdiliste, tabell)
         return tabell
     }
@@ -187,6 +201,12 @@ object PdfElementUtils {
         }
         return mørkBakgrunn
     }
+
+    fun oppdaterSpråk(feltMap: FeltMap) {
+        Konfigurasjon.språk = feltMap.pdfConfig.språk
+    }
+
+    fun brukSpråk(): String = (Konfigurasjon.språk)
 
     private fun lagTabellInformasjonscelle(
         tekst: String,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -29,11 +29,13 @@ import com.itextpdf.layout.properties.TabAlignment
 import com.itextpdf.layout.properties.TextAlignment
 import com.itextpdf.layout.properties.VerticalAlignment
 import com.itextpdf.pdfa.PdfADocument
+import no.nav.familie.pdf.pdf.PdfElementUtils.brukSpråk
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagOverskriftH1
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagOverskriftH2
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagOverskriftH3
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagVerdiElement
 import no.nav.familie.pdf.pdf.PdfElementUtils.navLogoBilde
+import no.nav.familie.pdf.pdf.PdfElementUtils.oppdaterSpråk
 import no.nav.familie.pdf.pdf.VisningsvariantUtils.håndterVisningsvariant
 import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.familie.pdf.pdf.domain.VerdilisteElement
@@ -63,9 +65,12 @@ object PdfUtils {
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
         val innholdsfortegnelse = mutableListOf<InnholdsfortegnelseOppføringer>()
-        val sideantallInnholdsfortegnelse = if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse) else 0
+        val sideantallInnholdsfortegnelse =
+            if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse) else 0
 
         UtilsMetaData.leggtilMetaData(pdfADokument, feltMap)
+
+        oppdaterSpråk(feltMap)
 
         Document(pdfADokument).apply {
             settFont(FontStil.REGULAR)
@@ -195,7 +200,14 @@ object PdfUtils {
             )
         }
 
-        add(lagOverskriftH2("Innholdsfortegnelse"))
+        val innholdsfortegnelse: String =
+            when (brukSpråk()) {
+                "nn" -> "Innhaldsliste"
+                "en" -> "Table of Contents"
+                else -> "Innholdsfortegnelse"
+            }
+
+        add(lagOverskriftH2(innholdsfortegnelse))
         add(lagInnholdsfortegnelse(innholdsfortegnelseOppføringer))
     }
 
@@ -226,7 +238,19 @@ object PdfUtils {
 
     private fun Document.leggTilSidevisning(pdfADokument: PdfADocument) {
         for (sidetall in 1..pdfADokument.numberOfPages) {
-            val bunntekst = Paragraph().add("Side $sidetall av ${pdfADokument.numberOfPages}")
+            val side: String =
+                when (brukSpråk()) {
+                    "nn" -> "Side"
+                    "en" -> "Page"
+                    else -> "Side"
+                }
+            val av: String =
+                when (brukSpråk()) {
+                    "nn" -> "av"
+                    "en" -> "of"
+                    else -> "av"
+                }
+            val bunntekst = Paragraph().add("$side $sidetall $av ${pdfADokument.numberOfPages}")
             showTextAligned(bunntekst, 559f, 30f, sidetall, TextAlignment.RIGHT, VerticalAlignment.BOTTOM, 0f)
         }
     }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/VisningsvariantUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/VisningsvariantUtils.kt
@@ -47,9 +47,15 @@ object VisningsvariantUtils {
         verdilisteElement: VerdilisteElement,
         seksjon: Div,
     ) {
+        val ingenVedlegg: String =
+            when (PdfElementUtils.brukSpråk()) {
+                "nn" -> "Ingen vedlegg lasta opp i denne søknaden"
+                "en" -> "No attachments uploaded in this application"
+                else -> "Ingen vedlegg lastet opp i denne søknaden"
+            }
         verdilisteElement.verdiliste?.forEach { vedlegg ->
             vedlegg.verdi?.takeIf { it.isEmpty() }?.let {
-                seksjon.apply { add(lagTekstElement("Ingen vedlegg lastet opp i denne søknaden").apply { setMarginLeft(15f) }) }
+                seksjon.apply { add(lagTekstElement(ingenVedlegg).apply { setMarginLeft(15f) }) }
             } ?: håndterRekursivVerdiliste(verdilisteElement.verdiliste, seksjon)
         }
     }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -18,3 +18,7 @@ data class PdfConfig(
     val harInnholdsfortegnelse: Boolean,
     val språk: String,
 )
+
+object Konfigurasjon {
+    var språk: String = "nb"
+}

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -356,6 +356,6 @@
   ],
   "pdfConfig": {
     "harInnholdsfortegnelse": true,
-    "språk": "NB"
+    "språk": "nb"
   }
 }


### PR DESCRIPTION
Denne PR-en legger til støtte for nynorsk (nn) og engelsk (en) i konfigurasjonen. Standard språk (nb) beholdes, men systemet kan nå håndtere flere språk.

