### PR TITLE
Legger til : på slutten av setninger uten punktsetting for bedre UU

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -29,7 +29,13 @@ object PdfElementUtils {
         Paragraph().apply {
             (element.label)
                 .takeIf { it.isNotEmpty() }
-                ?.let { add(Text(it).apply { settFont(FontStil.SEMIBOLD) }) }
+                ?.let {
+                    add(
+                        Text(leggTilKolon(it)).apply {
+                            settFont(FontStil.SEMIBOLD)
+                        },
+                    )
+                }
             element.alternativer?.takeIf { it.isNotEmpty() }?.let {
                 add(Text("\n"))
                 add(
@@ -44,6 +50,14 @@ object PdfElementUtils {
             setFontSize(12f)
             isKeepTogether = true
             accessibilityProperties.role = StandardRoles.P
+        }
+
+    // Kun dersom streng ikke har tegn bakerst
+    private fun leggTilKolon(tekst: String): String =
+        if (tekst.lastOrNull()?.let { it !in setOf('?', ':', '.', '!', ';') } == true) {
+            "$tekst:"
+        } else {
+            tekst
         }
 
     fun lagPunktliste(element: VerdilisteElement): Paragraph =

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -54,7 +54,7 @@ object PdfElementUtils {
 
     // Kun dersom streng ikke har tegn bakerst
     private fun leggTilKolon(tekst: String): String =
-        if (tekst.lastOrNull()?.let { it !in setOf('?', ':', '.', '!', ';') } == true) {
+        if (tekst.last() !in setOf('?', ':', '.', '!', ';')) {
             "$tekst:"
         } else {
             tekst

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.pdf.pdf
+
+import com.itextpdf.layout.element.Text
+import no.nav.familie.pdf.pdf.PdfElementUtils.lagVerdiElement
+import no.nav.familie.pdf.pdf.domain.VerdilisteElement
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PdfElementUtilsTest {
+    // Region lagVerdiElement
+    @Test
+    fun `leggTilKolon legger til kolon dersom label ikke har et tegn på slutten av spørsmål`() {
+        // Arrange
+        val testScenarioer =
+            listOf(
+                "Bor du på denne adressen" to "Bor du på denne adressen:",
+                "Bor du på denne adressen:" to "Bor du på denne adressen:",
+                "Bor du på denne adressen?" to "Bor du på denne adressen?",
+                "Bor du på denne adressen." to "Bor du på denne adressen.",
+                "Bor du på denne adressen!" to "Bor du på denne adressen!",
+                "Bor du på denne adressen;" to "Bor du på denne adressen;",
+            )
+
+        for ((inputVerdi, forventetVerdi) in testScenarioer) {
+            // Act
+            val verdilisteElement = VerdilisteElement(label = inputVerdi, verdi = "Ja")
+            val verdiElement = lagVerdiElement(verdilisteElement)
+            val tekstInnhold =
+                verdiElement.children
+                    .filterIsInstance<Text>()
+                    .joinToString("") { it.text }
+
+            // Assert
+            assertTrue(tekstInnhold.contains(forventetVerdi), "For input '$inputVerdi', forventet '$forventetVerdi', men fikk '$tekstInnhold'")
+        }
+    }
+
+    //endregion
+}


### PR DESCRIPTION
Legger til ':' på slutten av strenger dersom det ikke er annen punktsetting, for bedre lesbarhet ved bruk av skjermleser