### PR TITLE
skjemanummer i underoverskrift for at brukere av skjermlesere forstår hva brevkoden betyr

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -63,8 +63,8 @@ object PdfUtils {
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
         val innholdsfortegnelse = mutableListOf<InnholdsfortegnelseOppføringer>()
-        val brevkode = feltMap.brevkode
-        val sideantallInnholdsfortegnelse = if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse, brevkode) else 0
+
+        val sideantallInnholdsfortegnelse = if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse) else 0
 
         UtilsMetaData.leggtilMetaData(pdfADokument, feltMap)
 
@@ -78,7 +78,7 @@ object PdfUtils {
                 sideantallInnholdsfortegnelse,
             )
             if (harInnholdsfortegnelse) {
-                leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, brevkode)
+                leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.brevkode)
                 leggInnholdsfortegnelsenFørst(sideantallInnholdsfortegnelse, pdfADokument)
             }
 
@@ -90,7 +90,6 @@ object PdfUtils {
     private fun kalkulerSideantallInnholdsfortegnelse(
         feltMap: FeltMap,
         innholdsfortegnelse: MutableList<InnholdsfortegnelseOppføringer>,
-        brevkode: String?,
     ): Int {
         val midlertidigPdfADokument = lagPdfADocument(ByteArrayOutputStream())
         Document(midlertidigPdfADokument).apply {
@@ -101,7 +100,7 @@ object PdfUtils {
                 midlertidigPdfADokument,
             )
             val sideAntallFørInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
-            leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, brevkode)
+            leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.brevkode)
             val sideAntallEtterInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
             close()
             innholdsfortegnelse.clear()

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -188,13 +188,7 @@ object PdfUtils {
         add(AreaBreak(AreaBreakType.NEXT_PAGE))
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        if (!brevkode.isNullOrEmpty()) {
-            add(
-                Paragraph(brevkode).apply {
-                    setMarginTop(-10f)
-                },
-            )
-        }
+        setBrevkode(this, brevkode)
 
         add(lagOverskriftH2("Innholdsfortegnelse"))
         add(lagInnholdsfortegnelse(innholdsfortegnelseOppføringer))
@@ -207,13 +201,7 @@ object PdfUtils {
         val tittel = overskrift.substringBefore(" (")
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        if (!brevkode.isNullOrEmpty()) {
-            add(
-                Paragraph(brevkode).apply {
-                    setMarginTop(-10f)
-                },
-            )
-        }
+        setBrevkode(this, brevkode)
     }
 
     private fun leggInnholdsfortegnelsenFørst(
@@ -308,5 +296,18 @@ object PdfUtils {
         REGULAR,
         SEMIBOLD,
         ITALIC,
+    }
+
+    private fun setBrevkode(
+        document: Document,
+        brevkode: String?,
+    ) {
+        if (!brevkode.isNullOrEmpty()) {
+            document.add(
+                Paragraph(brevkode).apply {
+                    setMarginTop(-10f)
+                },
+            )
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -78,7 +78,7 @@ object PdfUtils {
                 sideantallInnholdsfortegnelse,
             )
             if (harInnholdsfortegnelse) {
-                leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.brevkode)
+                leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.skjemanummer)
                 leggInnholdsfortegnelsenFørst(sideantallInnholdsfortegnelse, pdfADokument)
             }
 
@@ -100,7 +100,7 @@ object PdfUtils {
                 midlertidigPdfADokument,
             )
             val sideAntallFørInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
-            leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.brevkode)
+            leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.skjemanummer)
             val sideAntallEtterInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
             close()
             innholdsfortegnelse.clear()
@@ -116,7 +116,7 @@ object PdfUtils {
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
         if (!harInnholdsfortegnelse) {
-            leggTilForsideOgSeksjonerUtenInnholdsfortegnelse(feltMap.label, feltMap.brevkode)
+            leggTilForsideOgSeksjonerUtenInnholdsfortegnelse(feltMap.label, feltMap.skjemanummer)
         }
         feltMap.verdiliste.forEach { element ->
             element.verdiliste.let {
@@ -182,13 +182,13 @@ object PdfUtils {
     private fun Document.leggTilForsideMedInnholdsfortegnelse(
         overskrift: String,
         innholdsfortegnelseOppføringer: List<InnholdsfortegnelseOppføringer>,
-        brevkode: String?,
+        skjemanummer: String?,
     ) {
         val tittel = overskrift.substringBefore(" (")
         add(AreaBreak(AreaBreakType.NEXT_PAGE))
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        setBrevkode(this, brevkode)
+        setSkjemanummer(this, skjemanummer)
 
         add(lagOverskriftH2("Innholdsfortegnelse"))
         add(lagInnholdsfortegnelse(innholdsfortegnelseOppføringer))
@@ -196,12 +196,12 @@ object PdfUtils {
 
     private fun Document.leggTilForsideOgSeksjonerUtenInnholdsfortegnelse(
         overskrift: String,
-        brevkode: String?,
+        skjemanummer: String?,
     ) {
         val tittel = overskrift.substringBefore(" (")
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        setBrevkode(this, brevkode)
+        setSkjemanummer(this, skjemanummer)
     }
 
     private fun leggInnholdsfortegnelsenFørst(
@@ -298,13 +298,13 @@ object PdfUtils {
         ITALIC,
     }
 
-    private fun setBrevkode(
+    private fun setSkjemanummer(
         document: Document,
-        brevkode: String?,
+        skjemanummer: String?,
     ) {
-        if (!brevkode.isNullOrEmpty()) {
+        if (!skjemanummer.isNullOrEmpty()) {
             document.add(
-                Paragraph(brevkode).apply {
+                Paragraph(skjemanummer).apply {
                     setMarginTop(-10f)
                 },
             )

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -184,9 +184,8 @@ object PdfUtils {
         innholdsfortegnelseOppføringer: List<InnholdsfortegnelseOppføringer>,
         skjemanummer: String?,
     ) {
-        val tittel = overskrift.substringBefore(" (")
         add(AreaBreak(AreaBreakType.NEXT_PAGE))
-        add(lagOverskriftH1(tittel))
+        add(lagOverskriftH1(overskrift))
         add(navLogoBilde())
         setSkjemanummer(this, skjemanummer)
 
@@ -198,8 +197,7 @@ object PdfUtils {
         overskrift: String,
         skjemanummer: String?,
     ) {
-        val tittel = overskrift.substringBefore(" (")
-        add(lagOverskriftH1(tittel))
+        add(lagOverskriftH1(overskrift))
         add(navLogoBilde())
         setSkjemanummer(this, skjemanummer)
     }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -63,7 +63,8 @@ object PdfUtils {
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
         val innholdsfortegnelse = mutableListOf<InnholdsfortegnelseOppføringer>()
-        val sideantallInnholdsfortegnelse = if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse) else 0
+        val brevkode = feltMap.brevkode
+        val sideantallInnholdsfortegnelse = if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse, brevkode) else 0
 
         UtilsMetaData.leggtilMetaData(pdfADokument, feltMap)
 
@@ -77,7 +78,7 @@ object PdfUtils {
                 sideantallInnholdsfortegnelse,
             )
             if (harInnholdsfortegnelse) {
-                leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse)
+                leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, brevkode)
                 leggInnholdsfortegnelsenFørst(sideantallInnholdsfortegnelse, pdfADokument)
             }
 
@@ -89,6 +90,7 @@ object PdfUtils {
     private fun kalkulerSideantallInnholdsfortegnelse(
         feltMap: FeltMap,
         innholdsfortegnelse: MutableList<InnholdsfortegnelseOppføringer>,
+        brevkode: String?,
     ): Int {
         val midlertidigPdfADokument = lagPdfADocument(ByteArrayOutputStream())
         Document(midlertidigPdfADokument).apply {
@@ -99,7 +101,7 @@ object PdfUtils {
                 midlertidigPdfADokument,
             )
             val sideAntallFørInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
-            leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse)
+            leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, brevkode)
             val sideAntallEtterInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
             close()
             innholdsfortegnelse.clear()
@@ -115,7 +117,7 @@ object PdfUtils {
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
         if (!harInnholdsfortegnelse) {
-            leggTilForsideOgSeksjonerUtenInnholdsfortegnelse(feltMap.label)
+            leggTilForsideOgSeksjonerUtenInnholdsfortegnelse(feltMap.label, feltMap.brevkode)
         }
         feltMap.verdiliste.forEach { element ->
             element.verdiliste.let {
@@ -181,15 +183,15 @@ object PdfUtils {
     private fun Document.leggTilForsideMedInnholdsfortegnelse(
         overskrift: String,
         innholdsfortegnelseOppføringer: List<InnholdsfortegnelseOppføringer>,
+        brevkode: String?,
     ) {
         val tittel = overskrift.substringBefore(" (")
-        val søknadstype = overskrift.substringAfter(" (", "").trimEnd(')')
         add(AreaBreak(AreaBreakType.NEXT_PAGE))
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        if (søknadstype.isNotEmpty()) {
+        if (!brevkode.isNullOrEmpty()) {
             add(
-                Paragraph(søknadstype).apply {
+                Paragraph(brevkode).apply {
                     setMarginTop(-10f)
                 },
             )
@@ -201,14 +203,14 @@ object PdfUtils {
 
     private fun Document.leggTilForsideOgSeksjonerUtenInnholdsfortegnelse(
         overskrift: String,
+        brevkode: String?,
     ) {
         val tittel = overskrift.substringBefore(" (")
-        val søknadstype = overskrift.substringAfter(" (", "").trimEnd(')')
         add(lagOverskriftH1(tittel))
         add(navLogoBilde())
-        if (søknadstype.isNotEmpty()) {
+        if (!brevkode.isNullOrEmpty()) {
             add(
-                Paragraph(søknadstype).apply {
+                Paragraph(brevkode).apply {
                     setMarginTop(-10f)
                 },
             )

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -4,6 +4,7 @@ data class FeltMap(
     val label: String,
     val verdiliste: List<VerdilisteElement>,
     val pdfConfig: PdfConfig,
+    val brevkode: String? = null,
 )
 
 data class VerdilisteElement(

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/FeltMap.kt
@@ -4,7 +4,7 @@ data class FeltMap(
     val label: String,
     val verdiliste: List<VerdilisteElement>,
     val pdfConfig: PdfConfig,
-    val brevkode: String? = null,
+    val skjemanummer: String? = null,
 )
 
 data class VerdilisteElement(

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -9,11 +9,11 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedBarneTabell
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedFlereArbeidsforhold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedForskjelligLabelIVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedInnholdsfortegnelse
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomBrevkode
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomtSkjemanummer
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUtenBrevkode
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUtenSkjemanummer
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUteninnholdsfortegnelse
 import no.nav.familie.pdf.pdf.PdfService
 import no.nav.familie.pdf.pdf.domain.FeltMap
@@ -45,10 +45,10 @@ class PdfServiceTest {
             )
 
         @JvmStatic
-        fun underOverskriftUtenBrevkode(): Stream<FeltMap> =
+        fun underOverskriftUtenSkjemanummer(): Stream<FeltMap> =
             Stream.of(
-                lagMedTomBrevkode(),
-                lagUtenBrevkode(),
+                lagMedTomtSkjemanummer(),
+                lagUtenSkjemanummer(),
             )
     }
 
@@ -101,7 +101,7 @@ class PdfServiceTest {
 
     //region Innholdsfortegnelse
     @Test
-    fun `Pdf har brevkode i under-overskriften`() {
+    fun `Pdf har skjemanummer i under-overskriften`() {
         // Arrange
         val feltMap = lagMedVerdiliste()
 
@@ -111,18 +111,18 @@ class PdfServiceTest {
 
         // Assert
         assertTrue(førsteSidePdf.contains("Søknad om overgangsstønad"))
-        assertTrue(førsteSidePdf.contains("Brevkode: NAV 15-00.01"))
+        assertTrue(førsteSidePdf.contains("Skjemanummer: NAV 15-00.01"))
     }
 
     @ParameterizedTest
-    @MethodSource("underOverskriftUtenBrevkode")
-    fun `Pdf har ikke brevkode i overskrift`(feltMap: FeltMap) {
+    @MethodSource("underOverskriftUtenSkjemanummer")
+    fun `Pdf har ikke skjemanummer i overskrift`(feltMap: FeltMap) {
         // Act
         val pdfDoc = opprettPdf(feltMap)
         val førsteSidePdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
 
         // Assert
-        assertFalse(førsteSidePdf.contains("Brevkode: NAV 15-00.01"))
+        assertFalse(førsteSidePdf.contains("Skjemanummer: NAV 15-00.01"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -139,20 +139,6 @@ class PdfServiceTest {
         assertTrue(1 == antallForekomster, "Overskriften dukker opp to ganger")
     }
 
-    @Test
-    fun `Pdf har ikke parenteser i overskrift`() {
-        // Arrange
-        val feltMap = lagMedVerdiliste()
-
-        // Act
-        val pdfDoc = opprettPdf(feltMap)
-        val førsteSidePdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
-
-        // Assert
-        assertFalse(førsteSidePdf.contains("("), "Overskriften inneholder '('")
-        assertFalse(førsteSidePdf.contains(")"), "Overskriften inneholder ')'")
-    }
-
     @ParameterizedTest
     @MethodSource("innholdsfortegnelseMedEnOgToSider")
     fun `Pdf legger forside med innholdsfortegnelse først`(feltMap: FeltMap) {

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -9,9 +9,11 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedBarneTabell
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedFlereArbeidsforhold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedForskjelligLabelIVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedInnholdsfortegnelse
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomBrevkode
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUtenBrevkode
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUteninnholdsfortegnelse
 import no.nav.familie.pdf.pdf.PdfService
 import no.nav.familie.pdf.pdf.domain.FeltMap
@@ -40,6 +42,13 @@ class PdfServiceTest {
             Stream.of(
                 lagMedVerdiliste(),
                 lagToSiderInnholdsfortegnelse(),
+            )
+
+        @JvmStatic
+        fun underOverskriftUtenBrevkode(): Stream<FeltMap> =
+            Stream.of(
+                lagMedTomBrevkode(),
+                lagUtenBrevkode(),
             )
     }
 
@@ -92,7 +101,7 @@ class PdfServiceTest {
 
     //region Innholdsfortegnelse
     @Test
-    fun `Pdf har søknadstype i overskrift`() {
+    fun `Pdf har brevkode i under-overskriften`() {
         // Arrange
         val feltMap = lagMedVerdiliste()
 
@@ -103,6 +112,17 @@ class PdfServiceTest {
         // Assert
         assertTrue(førsteSidePdf.contains("Søknad om overgangsstønad"))
         assertTrue(førsteSidePdf.contains("Brevkode: NAV 15-00.01"))
+    }
+
+    @ParameterizedTest
+    @MethodSource("underOverskriftUtenBrevkode")
+    fun `Pdf har ikke brevkode i overskrift`(feltMap: FeltMap) {
+        // Act
+        val pdfDoc = opprettPdf(feltMap)
+        val førsteSidePdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(1))
+
+        // Assert
+        assertFalse(førsteSidePdf.contains("Brevkode: NAV 15-00.01"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -5,13 +5,10 @@ import com.itextpdf.kernel.pdf.PdfReader
 import com.itextpdf.kernel.pdf.PdfWriter
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.pdfa.PdfADocument
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedBareLinjeskift
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagAdresseMedFlereLinjeskift
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedBarneTabell
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedFlereArbeidsforhold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedForskjelligLabelIVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedInnholdsfortegnelse
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomAdresse
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
@@ -105,7 +102,7 @@ class PdfServiceTest {
 
         // Assert
         assertTrue(førsteSidePdf.contains("Søknad om overgangsstønad"))
-        assertTrue(førsteSidePdf.contains("NAV 15-00.01"))
+        assertTrue(førsteSidePdf.contains("Brevkode: NAV 15-00.01"))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -211,3 +211,39 @@ fun lagMedInnholdsfortegnelse(): FeltMap =
             ),
     )
 //endregion
+
+//region brevKode
+fun lagMedTomBrevkode(): FeltMap =
+    FeltMap(
+        label = søknadsTittel,
+        verdiliste =
+            listOf(
+                VerdilisteElement(
+                    label = "Innsendingsdetaljer",
+                    verdiliste =
+                        listOf(
+                            VerdilisteElement(label = "Navn", verdi = "Kåre"),
+                            VerdilisteElement(label = "Født", verdi = "Ja"),
+                        ),
+                ),
+            ),
+        pdfConfig = PdfConfig(true, "nb"),
+        brevkode = "",
+    )
+
+fun lagUtenBrevkode(): FeltMap =
+    FeltMap(
+        label = søknadsTittel,
+        verdiliste =
+            listOf(
+                VerdilisteElement(
+                    label = "Innsendingsdetaljer",
+                    verdiliste =
+                        listOf(
+                            VerdilisteElement(label = "Navn", verdi = "Kåre"),
+                            VerdilisteElement(label = "Født", verdi = "Ja"),
+                        ),
+                ),
+            ),
+        pdfConfig = PdfConfig(true, "nb"),
+    )

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -25,7 +25,7 @@ fun lagMedVerdiliste(): FeltMap =
                 ),
             ),
         pdfConfig = PdfConfig(true, "nb"),
-        brevkode = "Brevkode: NAV 15-00.01",
+        skjemanummer = "Skjemanummer: NAV 15-00.01",
     )
 
 fun lagMedForskjelligLabelIVerdiliste(): FeltMap =
@@ -212,23 +212,23 @@ fun lagMedInnholdsfortegnelse(): FeltMap =
     )
 //endregion
 
-//region brevKode
-fun lagMedTomBrevkode(): FeltMap =
+//region Skjemanummer
+fun lagMedTomtSkjemanummer(): FeltMap =
     FeltMap(
         label = søknadsTittel,
         verdiliste =
             listOf(innsendingsdetaljer),
         pdfConfig = PdfConfig(true, "nb"),
-        brevkode = "",
+        skjemanummer = "",
     )
 
-fun lagUtenBrevkode(): FeltMap =
+fun lagUtenSkjemanummer(): FeltMap =
     FeltMap(
         label = søknadsTittel,
         verdiliste =
             listOf(innsendingsdetaljer),
         pdfConfig = PdfConfig(true, "nb"),
-        brevkode = null,
+        skjemanummer = null,
     )
 
 val innsendingsdetaljer =

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -217,16 +217,7 @@ fun lagMedTomBrevkode(): FeltMap =
     FeltMap(
         label = søknadsTittel,
         verdiliste =
-            listOf(
-                VerdilisteElement(
-                    label = "Innsendingsdetaljer",
-                    verdiliste =
-                        listOf(
-                            VerdilisteElement(label = "Navn", verdi = "Kåre"),
-                            VerdilisteElement(label = "Født", verdi = "Ja"),
-                        ),
-                ),
-            ),
+            listOf(innsendingsdetaljer),
         pdfConfig = PdfConfig(true, "nb"),
         brevkode = "",
     )
@@ -235,15 +226,17 @@ fun lagUtenBrevkode(): FeltMap =
     FeltMap(
         label = søknadsTittel,
         verdiliste =
-            listOf(
-                VerdilisteElement(
-                    label = "Innsendingsdetaljer",
-                    verdiliste =
-                        listOf(
-                            VerdilisteElement(label = "Navn", verdi = "Kåre"),
-                            VerdilisteElement(label = "Født", verdi = "Ja"),
-                        ),
-                ),
-            ),
+            listOf(innsendingsdetaljer),
         pdfConfig = PdfConfig(true, "nb"),
+        brevkode = null,
+    )
+
+val innsendingsdetaljer =
+    VerdilisteElement(
+        label = "Innsendingsdetaljer",
+        verdiliste =
+            listOf(
+                VerdilisteElement(label = "Navn", verdi = "Kåre"),
+                VerdilisteElement(label = "Født", verdi = "Ja"),
+            ),
     )

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -25,6 +25,7 @@ fun lagMedVerdiliste(): FeltMap =
                 ),
             ),
         pdfConfig = PdfConfig(true, "nb"),
+        brevkode = "Brevkode: NAV 15-00.01",
     )
 
 fun lagMedForskjelligLabelIVerdiliste(): FeltMap =

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -358,5 +358,5 @@
     "harInnholdsfortegnelse": true,
     "språk": "NB"
   },
-  "brevkode": "Brevkode: NAV 15-00.01"
+  "skjemanummer": "Skjemanummer: NAV 15-00.01"
 }

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -357,5 +357,6 @@
   "pdfConfig": {
     "harInnholdsfortegnelse": true,
     "språk": "NB"
-  }
+  },
+  "brevkode": "Brevkode: NAV 15-00.01"
 }


### PR DESCRIPTION
Endret:
- skjemanummer i feltmap
- skjemanummer legges til i underoverskriften, uten splitting av overskrift slik det ble gjort før
