### PR TITLE
legge til margin for at separatorlinjen ikke skal gå over side x av y

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -70,6 +70,7 @@ object PdfUtils {
 
         Document(pdfADokument).apply {
             settFont(FontStil.REGULAR)
+            setMargins(36f, 36f, 44f, 36f)
 
             leggTilSeksjonerOgOppdaterInnholdsfortegnelse(
                 feltMap,
@@ -151,9 +152,7 @@ object PdfUtils {
                     håndterRekursivVerdiliste(element.verdiliste, this)
                 }
             }
-            add(LineSeparator(SolidLine().apply { color = DeviceRgb(131, 140, 154) })).apply {
-                setMarginBottom(10f)
-            }
+            add(LineSeparator(SolidLine().apply { color = DeviceRgb(131, 140, 154) }))
         }
 
     fun håndterRekursivVerdiliste(

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfUtils.kt
@@ -151,7 +151,9 @@ object PdfUtils {
                     håndterRekursivVerdiliste(element.verdiliste, this)
                 }
             }
-            add(LineSeparator(SolidLine().apply { color = DeviceRgb(131, 140, 154) }))
+            add(LineSeparator(SolidLine().apply { color = DeviceRgb(131, 140, 154) })).apply {
+                setMarginBottom(10f)
+            }
         }
 
     fun håndterRekursivVerdiliste(


### PR DESCRIPTION
https://www.notion.so/bekks/Board-fbe4467179454561b9b2a9f886462c1a?p=17d6bd30854180c8925de4a2925fa090&pm=s

- Legge til margin på bunn av siden for at innhold ikke skal gå over "side x av y"-elementet.
- 36f er default margin itext hvis margin ikke defineres

<img width="596" alt="image" src="https://github.com/user-attachments/assets/c886b759-4502-4d9e-b4b3-7b96585b1db8" />
