### PR TITLE
Utenlandsopphold tabell

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfElementUtils.kt
@@ -158,7 +158,7 @@ object PdfElementUtils {
         var mørkBakgrunn = harMørkBakgrunn
         tabellData.forEach { element ->
             when {
-                element.verdi != null -> {
+                element.label.isNotEmpty() && !element.verdi.isNullOrEmpty() -> {
                     val labelCelle = lagTabellInformasjonscelle(element.label, erUthevet = true)
                     val verdiCelle = lagTabellInformasjonscelle(element.verdi, false)
 
@@ -172,7 +172,7 @@ object PdfElementUtils {
                     mørkBakgrunn = !mørkBakgrunn
                 }
 
-                element.verdiliste != null -> {
+                !element.verdiliste.isNullOrEmpty() -> {
                     mørkBakgrunn = lagTabellRekursivt(element.verdiliste, tabell, mørkBakgrunn)
                 }
             }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
@@ -1,10 +1,14 @@
 package no.nav.familie.pdf.pdf
 
+import com.itextpdf.layout.element.Table
 import com.itextpdf.layout.element.Text
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedUtenlandsopphold
+import no.nav.familie.pdf.pdf.PdfElementUtils.lagTabell
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagVerdiElement
 import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
 
 class PdfElementUtilsTest {
     // Region lagVerdiElement
@@ -34,6 +38,28 @@ class PdfElementUtilsTest {
             assertTrue(tekstInnhold.contains(forventetVerdi), "For input '$inputVerdi', forventet '$forventetVerdi', men fikk '$tekstInnhold'")
         }
     }
-
     //endregion
+
+    // region tabell
+    @Test
+    fun `Utenlandsopphold sine objekter vises som Tabeller`() {
+        // Arrange
+        val feltMap = lagMedUtenlandsopphold()
+        val verdilisteElement =
+            feltMap.verdiliste
+                .first { it.label == "Opphold i Norge" }
+                .verdiliste
+                ?.first { it.label == "Utenlandsopphold" }
+
+        // Act
+        val resultat = if (verdilisteElement?.verdiliste != null) verdilisteElement.verdiliste?.map { lagTabell(it) } else null
+
+        // Assert
+        assertNotNull(resultat, "Resultatet er null")
+        resultat.forEach {
+            assertNotNull(it, "Tabell er null")
+            assertTrue(it is Table, "Elementet er ikke en tabell")
+        }
+    }
+    // endregion
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
@@ -2,15 +2,31 @@ package no.nav.familie.pdf.pdf
 
 import com.itextpdf.layout.element.Table
 import com.itextpdf.layout.element.Text
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedBarneTabell
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedFlereArbeidsforhold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedUtenlandsopphold
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagTabell
 import no.nav.familie.pdf.pdf.PdfElementUtils.lagVerdiElement
+import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 import kotlin.test.assertNotNull
 
 class PdfElementUtilsTest {
+    private companion object {
+        @JvmStatic
+        private fun tabell(): Stream<FeltMap> =
+            Stream.of(
+                lagMedBarneTabell(),
+                lagMedFlereArbeidsforhold(),
+                lagMedUtenlandsopphold(),
+            )
+    }
+
     // Region lagVerdiElement
     @Test
     fun `leggTilKolon legger til kolon dersom label ikke har et tegn på slutten av spørsmål`() {
@@ -41,7 +57,8 @@ class PdfElementUtilsTest {
     //endregion
 
     // region tabell
-    @Test
+    @ParameterizedTest
+    @MethodSource("tabell")
     fun `Utenlandsopphold sine objekter vises som Tabeller`() {
         // Arrange
         val feltMap = lagMedUtenlandsopphold()
@@ -61,5 +78,6 @@ class PdfElementUtilsTest {
             assertTrue(it is Table, "Elementet er ikke en tabell")
         }
     }
+
     // endregion
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
@@ -51,7 +51,10 @@ class PdfElementUtilsTest {
                     .joinToString("") { it.text }
 
             // Assert
-            assertTrue(tekstInnhold.contains(forventetVerdi), "For input '$inputVerdi', forventet '$forventetVerdi', men fikk '$tekstInnhold'")
+            assertTrue(
+                tekstInnhold.contains(forventetVerdi),
+                "For input '$inputVerdi', forventet '$forventetVerdi', men fikk '$tekstInnhold'",
+            )
         }
     }
     //endregion
@@ -59,17 +62,13 @@ class PdfElementUtilsTest {
     // region tabell
     @ParameterizedTest
     @MethodSource("tabell")
-    fun `Utenlandsopphold sine objekter vises som Tabeller`() {
+    fun `Utenlandsopphold sine objekter vises som Tabeller`(feltMap: FeltMap) {
         // Arrange
-        val feltMap = lagMedUtenlandsopphold()
-        val verdilisteElement =
-            feltMap.verdiliste
-                .first { it.label == "Opphold i Norge" }
-                .verdiliste
-                ?.first { it.label == "Utenlandsopphold" }
+        val verdilisteElement = fåFørsteElementMedTabellVariant(feltMap)
 
         // Act
-        val resultat = if (verdilisteElement?.verdiliste != null) verdilisteElement.verdiliste?.map { lagTabell(it) } else null
+        val resultat =
+            if (verdilisteElement?.verdiliste != null) verdilisteElement.verdiliste?.map { lagTabell(it) } else null
 
         // Assert
         assertNotNull(resultat, "Resultatet er null")
@@ -79,5 +78,17 @@ class PdfElementUtilsTest {
         }
     }
 
+    fun fåFørsteElementMedTabellVariant(feltMap: FeltMap): VerdilisteElement? {
+        fun traverse(verdiliste: List<VerdilisteElement>?): VerdilisteElement? {
+            verdiliste?.forEach { element ->
+                if (element.visningsVariant == "TABELL") {
+                    return element
+                }
+                traverse(element.verdiliste)?.let { return it }
+            }
+            return null
+        }
+        return traverse(feltMap.verdiliste)
+    }
     // endregion
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -13,7 +13,6 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedPunktliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomPunktliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomtSkjemanummer
-import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedUtenlandsopphold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUtenSkjemanummer
@@ -258,36 +257,6 @@ class PdfServiceTest {
         assertTrue(barn1Index < navnIndex)
         assertTrue(navnIndex < barn2Index)
         assertTrue(barn2Index < termindatoIndex)
-    }
-
-    @Test
-    fun `Utenlandsopphold vises i tabell-format`() {
-        // Act
-        var feltMap = lagMedUtenlandsopphold()
-
-        // Assert
-        val pdfDoc = opprettPdf(feltMap)
-        val tekstIPdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
-
-        // Assert
-        val landIndex = tekstIPdf.indexOf("Utenlandsopphold 1")
-        val fraIndex = tekstIPdf.indexOf("Fra:", landIndex)
-        val tilIndex = tekstIPdf.indexOf("Til:", fraIndex)
-        val land2Index = tekstIPdf.indexOf("Utenlandsopphold 2", tilIndex)
-        val fra2Index = tekstIPdf.indexOf("Fra:", land2Index)
-        val til2Index = tekstIPdf.indexOf("Til:", fra2Index)
-
-        assertTrue(landIndex != -1)
-        assertTrue(fraIndex != -1)
-        assertTrue(tilIndex != -1)
-        assertTrue(land2Index != -1)
-        assertTrue(fra2Index != -1)
-        assertTrue(til2Index != -1)
-        assertTrue(landIndex < fraIndex)
-        assertTrue(fraIndex < tilIndex)
-        assertTrue(tilIndex < land2Index)
-        assertTrue(land2Index < fra2Index)
-        assertTrue(fra2Index < til2Index)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedPunktliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomPunktliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomtSkjemanummer
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedUtenlandsopphold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUtenSkjemanummer
@@ -257,6 +258,36 @@ class PdfServiceTest {
         assertTrue(barn1Index < navnIndex)
         assertTrue(navnIndex < barn2Index)
         assertTrue(barn2Index < termindatoIndex)
+    }
+
+    @Test
+    fun `Utenlandsopphold vises i tabell-format`() {
+        // Act
+        var feltMap = lagMedUtenlandsopphold()
+
+        // Assert
+        val pdfDoc = opprettPdf(feltMap)
+        val tekstIPdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
+
+        // Assert
+        val landIndex = tekstIPdf.indexOf("Utenlandsopphold 1")
+        val fraIndex = tekstIPdf.indexOf("Fra:", landIndex)
+        val tilIndex = tekstIPdf.indexOf("Til:", fraIndex)
+        val land2Index = tekstIPdf.indexOf("Utenlandsopphold 2", tilIndex)
+        val fra2Index = tekstIPdf.indexOf("Fra:", land2Index)
+        val til2Index = tekstIPdf.indexOf("Til:", fra2Index)
+
+        assertTrue(landIndex != -1)
+        assertTrue(fraIndex != -1)
+        assertTrue(tilIndex != -1)
+        assertTrue(land2Index != -1)
+        assertTrue(fra2Index != -1)
+        assertTrue(til2Index != -1)
+        assertTrue(landIndex < fraIndex)
+        assertTrue(fraIndex < tilIndex)
+        assertTrue(tilIndex < land2Index)
+        assertTrue(land2Index < fra2Index)
+        assertTrue(fra2Index < til2Index)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -13,6 +13,7 @@ import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedPunktliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomPunktliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedTomtSkjemanummer
+import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedUtenlandsopphold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedVerdiliste
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagToSiderInnholdsfortegnelse
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagUtenSkjemanummer
@@ -58,6 +59,14 @@ class PdfServiceTest {
             Stream.of(
                 lagMedTomtSkjemanummer(),
                 lagUtenSkjemanummer(),
+            )
+
+        @JvmStatic
+        fun tabell(): Stream<FeltMap> =
+            Stream.of(
+                lagMedBarneTabell(),
+                lagMedFlereArbeidsforhold(),
+                lagMedUtenlandsopphold(),
             )
     }
 
@@ -211,52 +220,19 @@ class PdfServiceTest {
     //endregion
 
     //region Tabeller
-    @Test
-    fun `Pdf lager tabell dersom du har flere arbeidsforhold`() {
-        // Arrange
-        val feltMap = lagMedFlereArbeidsforhold()
-
-        // Act
-        val pdfDoc = opprettPdf(feltMap)
-        val tekstIPdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
-
-        // Assert
-        val arbeidsforhold1Index = tekstIPdf.indexOf("Arbeidsforhold 1")
-        val navnIndex = tekstIPdf.indexOf("Nav", arbeidsforhold1Index)
-        val arbeidsforhold2Index = tekstIPdf.indexOf("Arbeidsforhold 2", navnIndex)
-        val termindatoIndex = tekstIPdf.indexOf("Bekk", arbeidsforhold2Index)
-
-        assertTrue(arbeidsforhold1Index != -1)
-        assertTrue(navnIndex != -1)
-        assertTrue(arbeidsforhold2Index != -1)
-        assertTrue(termindatoIndex != -1)
-        assertTrue(arbeidsforhold1Index < navnIndex)
-        assertTrue(navnIndex < arbeidsforhold2Index)
-        assertTrue(arbeidsforhold2Index < termindatoIndex)
-    }
-
-    @Test
-    fun `Tabeller får inn en liste av objekter som tegnes som tabeller`() {
-        // Act
-        val feltMap = lagMedBarneTabell()
-
+    @ParameterizedTest
+    @MethodSource("tabell")
+    fun `Tabeller får inn en liste av objekter som tegnes som tabeller`(feltMap: FeltMap) {
         // Assert
         val pdfDoc = opprettPdf(feltMap)
         val tekstIPdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
 
         // Assert
-        val barn1Index = tekstIPdf.indexOf("Barn 1")
-        val navnIndex = tekstIPdf.indexOf("Navn", barn1Index)
-        val barn2Index = tekstIPdf.indexOf("Barn 2", navnIndex)
-        val termindatoIndex = tekstIPdf.indexOf("Termindato", barn2Index)
-
-        assertTrue(barn1Index != -1)
-        assertTrue(navnIndex != -1)
-        assertTrue(barn2Index != -1)
-        assertTrue(termindatoIndex != -1)
-        assertTrue(barn1Index < navnIndex)
-        assertTrue(navnIndex < barn2Index)
-        assertTrue(barn2Index < termindatoIndex)
+        val objekt1Index = tekstIPdf.indexOf("1")
+        val objekt2Index = tekstIPdf.indexOf("2", objekt1Index)
+        assertTrue(objekt1Index != -1)
+        assertTrue(objekt2Index != -1)
+        assertTrue(objekt1Index < objekt2Index)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -139,6 +139,48 @@ fun lagMedBarneTabell(): FeltMap =
         pdfConfig = PdfConfig(true, "nb"),
     )
 
+fun lagMedUtenlandsopphold(): FeltMap =
+    FeltMap(
+        label = søknadsTittel,
+        verdiliste =
+            listOf(
+                VerdilisteElement(
+                    label = "Opphold i Norge",
+                    verdiliste =
+                        listOf(
+                            VerdilisteElement(
+                                label = "Utenlandsopphold",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
+                                verdiliste =
+                                    listOf(
+                                        VerdilisteElement(
+                                            label = "Utenlandsopphold 1",
+                                            verdiliste =
+                                                listOf(
+                                                    VerdilisteElement(label = "Fra:", verdi = "2021-03-01"),
+                                                    VerdilisteElement(label = "Til:", verdi = "2021-04-01"),
+                                                    VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Danmark"),
+                                                    VerdilisteElement(label = "Hvorfor oppholdt du deg i Danmark?", verdi = "Ferie"),
+                                                ),
+                                        ),
+                                        VerdilisteElement(
+                                            label = "Utenlandsopphold 2",
+                                            verdiliste =
+                                                listOf(
+                                                    VerdilisteElement(label = "Fra:", verdi = "2021-04-01"),
+                                                    VerdilisteElement(label = "Til:", verdi = "2021-05-01"),
+                                                    VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Sverige"),
+                                                    VerdilisteElement(label = "Hvorfor oppholdt du deg i Sverige?", verdi = "Ferie"),
+                                                ),
+                                        ),
+                                    ),
+                            ),
+                        ),
+                ),
+            ),
+        pdfConfig = PdfConfig(true, "nb"),
+    )
+
 fun lagUteninnholdsfortegnelse(): FeltMap =
     FeltMap(
         label = søknadsTittel,

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -74,7 +74,43 @@
         },
         {
           "label": "Utenlandsopphold",
-          "verdiliste": []
+          "visningsVariant": "TABELL",
+          "verdiliste": [
+            {
+              "label": "Utenlandsopphold 1",
+              "verdiliste": [
+                {
+                  "label": "Fra dato",
+                  "verdi": "01.01.2020"
+                },
+                {
+                  "label": "Til dato",
+                  "verdi": "01.01.2021"
+                },
+                {
+                  "label": "Land",
+                  "verdi": "Sverige"
+                }
+              ]
+            },
+            {
+              "label": "Utenlandsopphold 2",
+              "verdiliste": [
+                {
+                  "label": "Fra dato",
+                  "verdi": "01.01.2021"
+                },
+                {
+                  "label": "Til dato",
+                  "verdi": "01.01.2022"
+                },
+                {
+                  "label": "Land",
+                  "verdi": "Danmark"
+                }
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Vedlagt er det main i mottak og denne branchen i pre-prod. Denne branchen er derfor tilbakekompatibel.

[Søknad om overgangsstønad - enslig mor eller far.pdf](https://github.com/user-attachments/files/18640924/Soknad.om.overgangsstonad.-.enslig.mor.eller.far.pdf)
Utenlandsopphold tabell-format: https://www.notion.so/bekks/Board-fbe4467179454561b9b2a9f886462c1a?p=15f6bd3085418009b691d6b037963a94&pm=s
Skal ikke merges før utenlandsopphold VerdilisteElement også sender med visningsvariant TABELL.

<img width="607" alt="Skjermbilde 2025-02-03 kl  08 50 04" src="https://github.com/user-attachments/assets/e2665b8a-64c9-4c74-8094-b2ea68ea4e67" />
