### PR TITLE
flytter visningsvariant TABELL til verdielementet

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/VisningsvariantUtils.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/VisningsvariantUtils.kt
@@ -19,7 +19,7 @@ object VisningsvariantUtils {
         if (verdilisteElement.verdiliste?.isNotEmpty() == true) {
             when (visningsVariant) {
                 VisningsVariant.TABELL.toString() -> {
-                    håndterTabeller(verdilisteElement.verdiliste, seksjon)
+                    håndterTabell(verdilisteElement, seksjon)
                 }
 
                 VisningsVariant.PUNKTLISTE.toString() -> {
@@ -33,12 +33,10 @@ object VisningsvariantUtils {
         }
     }
 
-    private fun håndterTabeller(
-        verdiliste: List<VerdilisteElement>,
+    private fun håndterTabell(
+        verdiliste: VerdilisteElement,
         seksjon: Div,
-    ) = verdiliste.forEach { verdilisteElement ->
-        verdiliste.let { seksjon.apply { add(lagTabell(verdilisteElement)) } }
-    }
+    ) = verdiliste.let { seksjon.apply { add(lagTabell(verdiliste)) } }
 
     private fun håndterPunktliste(
         verdi: VerdilisteElement,

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
@@ -62,20 +62,41 @@ class PdfElementUtilsTest {
     // region tabell
     @ParameterizedTest
     @MethodSource("tabell")
-    fun `Utenlandsopphold sine objekter vises som Tabeller`(feltMap: FeltMap) {
+    fun `Utenlandsopphold, arbeidsforhold og barna dine sine objekter vises som Tabell`(feltMap: FeltMap) {
         // Arrange
-        val verdilisteElement = fåFørsteElementMedTabellVariant(feltMap)
-
+        val verdilisteElement = finnFørsteElementMedTabellVariant(feltMap.verdiliste)
         // Act
         val resultat =
-            if (verdilisteElement?.verdiliste != null) verdilisteElement.verdiliste?.map { lagTabell(it) } else null
+            if (verdilisteElement?.verdiliste != null) lagTabell(verdilisteElement) else null
 
         // Assert
-        assertNotNull(resultat, "Resultatet er null")
-        resultat.forEach {
-            assertNotNull(it, "Tabell er null")
-            assertTrue(it is Table, "Elementet er ikke en tabell")
-        }
+        assertNotNull(resultat, "Tabell er null")
+        assertTrue(resultat is Table, "Elementet er ikke en tabell")
+    }
+
+    @ParameterizedTest
+    @MethodSource("tabell")
+    fun `Tabell har riktig antall kolonner og er en tabell`(feltMap: FeltMap) {
+        // Arrange
+        val verdilisteElement = finnFørsteElementMedTabellVariant(feltMap.verdiliste)
+        // Act
+        val resultat =
+            if (verdilisteElement?.verdiliste != null) lagTabell(verdilisteElement) else null
+
+        // Assert
+        assertNotNull(resultat, "Tabell er null")
+        assertTrue(resultat is Table, "Elementet er ikke en tabell")
+
+        // Additional checks
+        val table = resultat as Table
+        val numberOfColumns = table.numberOfColumns
+        val numberOfRows = table.numberOfRows
+
+        // Check the number of columns
+        assertTrue(numberOfColumns == 2, "Tabellen skal ha 2 kolonner, men har $numberOfColumns")
+
+        // Check the number of rows
+        assertTrue(numberOfRows > 0, "Tabellen skal ha minst 1 rad, men har $numberOfRows")
     }
 
     fun fåFørsteElementMedTabellVariant(feltMap: FeltMap): VerdilisteElement? {
@@ -90,5 +111,13 @@ class PdfElementUtilsTest {
         }
         return traverse(feltMap.verdiliste)
     }
+
+    fun finnFørsteElementMedTabellVariant(verdiliste: List<VerdilisteElement>): VerdilisteElement? =
+        verdiliste.firstOrNull { it.visningsVariant == "TABELL" }
+            ?: verdiliste
+                .asSequence()
+                .mapNotNull { it.verdiliste?.let(::finnFørsteElementMedTabellVariant) }
+                .firstOrNull()
+
     // endregion
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -77,11 +77,11 @@ fun lagMedFlereArbeidsforhold(): FeltMap =
                             ),
                             VerdilisteElement(
                                 label = "Om arbeidsforholdet ditt",
-                                visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
                                         VerdilisteElement(
                                             label = "Arbeidsforhold 1",
+                                            visningsVariant = VisningsVariant.TABELL.toString(),
                                             verdiliste =
                                                 listOf(
                                                     VerdilisteElement(
@@ -92,6 +92,7 @@ fun lagMedFlereArbeidsforhold(): FeltMap =
                                         ),
                                         VerdilisteElement(
                                             label = "Arbeidsforhold 2",
+                                            visningsVariant = VisningsVariant.TABELL.toString(),
                                             verdiliste =
                                                 listOf(
                                                     VerdilisteElement(
@@ -115,11 +116,11 @@ fun lagMedBarneTabell(): FeltMap =
             listOf(
                 VerdilisteElement(
                     label = "Barna dine",
-                    visningsVariant = VisningsVariant.TABELL.toString(),
                     verdiliste =
                         listOf(
                             VerdilisteElement(
                                 label = "Barn 1",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
                                         VerdilisteElement(label = "Navn", verdi = "Kåre"),
@@ -127,6 +128,7 @@ fun lagMedBarneTabell(): FeltMap =
                             ),
                             VerdilisteElement(
                                 label = "Barn 2",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
                                         VerdilisteElement(label = "Navn", verdi = ""),
@@ -149,30 +151,25 @@ fun lagMedUtenlandsopphold(): FeltMap =
                     verdiliste =
                         listOf(
                             VerdilisteElement(
-                                label = "Utenlandsopphold",
+                                label = "Utenlandsopphold 1",
                                 visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
-                                        VerdilisteElement(
-                                            label = "Utenlandsopphold 1",
-                                            verdiliste =
-                                                listOf(
-                                                    VerdilisteElement(label = "Fra:", verdi = "2021-03-01"),
-                                                    VerdilisteElement(label = "Til:", verdi = "2021-04-01"),
-                                                    VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Danmark"),
-                                                    VerdilisteElement(label = "Hvorfor oppholdt du deg i Danmark?", verdi = "Ferie"),
-                                                ),
-                                        ),
-                                        VerdilisteElement(
-                                            label = "Utenlandsopphold 2",
-                                            verdiliste =
-                                                listOf(
-                                                    VerdilisteElement(label = "Fra:", verdi = "2021-04-01"),
-                                                    VerdilisteElement(label = "Til:", verdi = "2021-05-01"),
-                                                    VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Sverige"),
-                                                    VerdilisteElement(label = "Hvorfor oppholdt du deg i Sverige?", verdi = "Ferie"),
-                                                ),
-                                        ),
+                                        VerdilisteElement(label = "Fra:", verdi = "2021-03-01"),
+                                        VerdilisteElement(label = "Til:", verdi = "2021-04-01"),
+                                        VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Danmark"),
+                                        VerdilisteElement(label = "Hvorfor oppholdt du deg i Danmark?", verdi = "Ferie"),
+                                    ),
+                            ),
+                            VerdilisteElement(
+                                label = "Utenlandsopphold 2",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
+                                verdiliste =
+                                    listOf(
+                                        VerdilisteElement(label = "Fra:", verdi = "2021-04-01"),
+                                        VerdilisteElement(label = "Til:", verdi = "2021-05-01"),
+                                        VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Sverige"),
+                                        VerdilisteElement(label = "Hvorfor oppholdt du deg i Sverige?", verdi = "Ferie"),
                                     ),
                             ),
                         ),

--- a/src/test/resources/overgangsstønad.json
+++ b/src/test/resources/overgangsstønad.json
@@ -116,10 +116,10 @@
     },
     {
       "label": "Barna dine",
-      "visningsVariant": "TABELL",
       "verdiliste": [
         {
           "label": "Barn 1",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Navn",

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -73,42 +73,38 @@
           "verdi": "Ja"
         },
         {
-          "label": "Utenlandsopphold",
+          "label": "Utenlandsopphold 1",
           "visningsVariant": "TABELL",
           "verdiliste": [
             {
-              "label": "Utenlandsopphold 1",
-              "verdiliste": [
-                {
-                  "label": "Fra dato",
-                  "verdi": "01.01.2020"
-                },
-                {
-                  "label": "Til dato",
-                  "verdi": "01.01.2021"
-                },
-                {
-                  "label": "Land",
-                  "verdi": "Sverige"
-                }
-              ]
+              "label": "Fra dato",
+              "verdi": "01.01.2020"
             },
             {
-              "label": "Utenlandsopphold 2",
-              "verdiliste": [
-                {
-                  "label": "Fra dato",
-                  "verdi": "01.01.2021"
-                },
-                {
-                  "label": "Til dato",
-                  "verdi": "01.01.2022"
-                },
-                {
-                  "label": "Land",
-                  "verdi": "Danmark"
-                }
-              ]
+              "label": "Til dato",
+              "verdi": "01.01.2021"
+            },
+            {
+              "label": "Land",
+              "verdi": "Sverige"
+            }
+          ]
+        },
+        {
+          "label": "Utenlandsopphold 2",
+          "visningsVariant": "TABELL",
+          "verdiliste": [
+            {
+              "label": "Fra dato",
+              "verdi": "01.01.2021"
+            },
+            {
+              "label": "Til dato",
+              "verdi": "01.01.2022"
+            },
+            {
+              "label": "Land",
+              "verdi": "Danmark"
             }
           ]
         }
@@ -134,10 +130,10 @@
     },
     {
       "label": "Barna dine",
-      "visningsVariant": "TABELL",
       "verdiliste": [
         {
           "label": "Barn 1",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Navn",
@@ -219,6 +215,7 @@
         },
         {
           "label": "Barn 2",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Har barnet samme adresse som deg?",
@@ -301,10 +298,10 @@
         },
         {
           "label": "Om arbeidsforholdet ditt",
-          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Arbeidsforhold 1",
+              "visningsVariant": "TABELL",
               "verdiliste": [
                 {
                   "label": "Navn på arbeidssted",
@@ -322,6 +319,7 @@
             },
             {
               "label": "Arbeidsforhold 2",
+              "visningsVariant": "TABELL",
               "verdiliste": [
                 {
                   "label": "Navn på arbeidssted",


### PR DESCRIPTION
Flytter visningsvariant TABELL til verdielementet som skal være tabell. 
Før lå visningsvarianten på foreldre-objektet. 