### PR TITLE
Flyttet visningsvariant TABELL til Verdielementet

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PDFdokument.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PDFdokument.kt
@@ -38,12 +38,13 @@ object PDFdokument {
     fun lagDokument(
         pdfADokument: PdfADocument,
         feltMap: FeltMap,
+        v2: Boolean,
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
         val innholdsfortegnelse = mutableListOf<InnholdsfortegnelseOppføringer>()
 
         val sideantallInnholdsfortegnelse =
-            if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse) else 0
+            if (harInnholdsfortegnelse) kalkulerSideantallInnholdsfortegnelse(feltMap, innholdsfortegnelse, v2) else 0
 
         leggtilMetaData(pdfADokument, feltMap)
 
@@ -55,6 +56,7 @@ object PDFdokument {
                 feltMap,
                 innholdsfortegnelse,
                 pdfADokument,
+                v2,
                 sideantallInnholdsfortegnelse,
             )
             if (harInnholdsfortegnelse) {

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PDFdokument.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PDFdokument.kt
@@ -45,7 +45,7 @@ object PDFdokument {
             setMargins(36f, 36f, 44f, 36f)
 
             if (feltMap.pdfConfig.harInnholdsfortegnelse) {
-                leggTilInnholdsfortegnelse(feltMap, genererInnholdsfortegnelseOppføringer(feltMap))
+                leggTilInnholdsfortegnelse(feltMap, genererInnholdsfortegnelseOppføringer(feltMap, v2))
             } else {
                 leggTilForside(feltMap.label, feltMap.skjemanummer)
             }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-@RequestMapping("api/v1/pdf")
+@RequestMapping("api/pdf")
 @ProtectedWithClaims(
     issuer = "azuread",
 )
@@ -21,7 +21,7 @@ class PdfController {
         val pdf: ByteArray,
     )
 
-    @PostMapping("/opprett-pdf")
+    @PostMapping("/v1/opprett-pdf")
     fun opprettPdf(
         @RequestBody søknad: FeltMap,
     ): ByteArray {
@@ -46,15 +46,8 @@ class PdfController {
             SpråkKontekst.tilbakestillSpråk()
         }
     }
-}
 
-@RestController
-@RequestMapping("api/v2/pdf")
-@ProtectedWithClaims(issuer = "azuread")
-class PdfControllerV2 {
-    private val pdfService = PdfService()
-
-    @PostMapping("/opprett-pdf")
+    @PostMapping("/v2/opprett-pdf")
     fun opprettPdfV2(
         @RequestBody søknad: FeltMap,
     ): ByteArray {

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfController.kt
@@ -20,7 +20,6 @@ class PdfController {
     fun opprettPdf(
         @RequestBody søknad: FeltMap,
     ): ByteArray {
-
         try {
             SpråkKontekst.settSpråk(søknad.pdfConfig.språk)
             val returverdi = pdfService.opprettPdf(søknad)
@@ -28,6 +27,24 @@ class PdfController {
         } finally {
             SpråkKontekst.tilbakestillSpråk()
         }
+    }
+}
 
+@RestController
+@RequestMapping("api/v2/pdf")
+@ProtectedWithClaims(issuer = "azuread")
+class PdfControllerV2 {
+    private val pdfService = PdfService()
+
+    @PostMapping("/opprett-pdf")
+    fun opprettPdfV2(
+        @RequestBody søknad: FeltMap,
+    ): ByteArray {
+        try {
+            SpråkKontekst.settSpråk(søknad.pdfConfig.språk)
+            return pdfService.opprettPdf(søknad, true)
+        } finally {
+            SpråkKontekst.tilbakestillSpråk()
+        }
     }
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -6,11 +6,13 @@ import no.nav.familie.pdf.pdf.PDFdokument.lagPdfADocument
 import no.nav.familie.pdf.pdf.domain.FeltMap
 
 class PdfService {
-    fun opprettPdf(feltMap: FeltMap): ByteArray {
+    fun opprettPdf(
+        feltMap: FeltMap,
+        v2: Boolean = false,
+    ): ByteArray {
         val byteArrayOutputStream = ByteArrayOutputStream()
         val pdfADokument = lagPdfADocument(byteArrayOutputStream)
-        lagDokument(pdfADokument, feltMap)
-
+        lagDokument(pdfADokument, feltMap, v2)
         return byteArrayOutputStream.toByteArray()
     }
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -14,3 +14,5 @@ class PdfService {
         return byteArrayOutputStream.toByteArray()
     }
 }
+
+// yhei

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/lokalKjøring/LokalPdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/lokalKjøring/LokalPdfService.kt
@@ -16,7 +16,7 @@ class LokalPdfService(
     }
 
     fun opprettPdfMedStandarder(feltMap: FeltMap): PdfMedStandarder {
-        val pdf = pdfService.opprettPdf(feltMap)
+        val pdf = pdfService.opprettPdf(feltMap, true)
         val pdfMedStandarder =
             PdfMedStandarder(
                 pdf,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Innholdsfortegnelse.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Innholdsfortegnelse.kt
@@ -29,6 +29,7 @@ object Innholdsfortegnelse {
     fun kalkulerSideantallInnholdsfortegnelse(
         feltMap: FeltMap,
         innholdsfortegnelse: MutableList<InnholdsfortegnelseOppføringer>,
+        v2: Boolean,
     ): Int {
         val midlertidigPdfADokument = PDFdokument.lagPdfADocument(ByteArrayOutputStream())
         Document(midlertidigPdfADokument).apply {
@@ -37,6 +38,7 @@ object Innholdsfortegnelse {
                 feltMap,
                 innholdsfortegnelse,
                 midlertidigPdfADokument,
+                v2,
             )
             val sideAntallFørInnholdsfortegnelse = midlertidigPdfADokument.numberOfPages
             leggTilForsideMedInnholdsfortegnelse(feltMap.label, innholdsfortegnelse, feltMap.skjemanummer)
@@ -51,6 +53,7 @@ object Innholdsfortegnelse {
         feltMap: FeltMap,
         innholdsfortegnelse: MutableList<InnholdsfortegnelseOppføringer>,
         pdfADokument: PdfADocument,
+        v2: Boolean,
         sideAntallInnholdsfortegnelse: Int = 0,
     ) {
         val harInnholdsfortegnelse = feltMap.pdfConfig.harInnholdsfortegnelse
@@ -60,7 +63,7 @@ object Innholdsfortegnelse {
         feltMap.verdiliste.forEach { element ->
             element.verdiliste.let {
                 val navigeringDestinasjon = element.label
-                add(lagSeksjon(element, navigeringDestinasjon))
+                add(lagSeksjon(element, navigeringDestinasjon, v2))
                 if (harInnholdsfortegnelse) {
                     innholdsfortegnelse.add(
                         InnholdsfortegnelseOppføringer(

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
@@ -10,6 +10,7 @@ import no.nav.familie.pdf.pdf.visningsvarianter.håndterVisningsvariant
 fun lagSeksjon(
     element: VerdilisteElement,
     navigeringDestinasjon: String,
+    v2: Boolean,
 ): Div =
     Div().apply {
         add(
@@ -19,9 +20,9 @@ fun lagSeksjon(
         )
         if (element.verdiliste != null) {
             if (element.visningsVariant != null) {
-                håndterVisningsvariant(element.visningsVariant, element, this)
+                håndterVisningsvariant(element.visningsVariant, element, v2, this)
             } else {
-                håndterRekursivVerdiliste(element.verdiliste, this)
+                håndterRekursivVerdiliste(element.verdiliste, this, v2)
             }
         }
         add(LineSeparator(SolidLine().apply { color = DeviceRgb(131, 140, 154) }))
@@ -30,6 +31,7 @@ fun lagSeksjon(
 fun håndterRekursivVerdiliste(
     verdiliste: List<VerdilisteElement>,
     seksjon: Div,
+    v2: Boolean,
     rekursjonsDybde: Int = 1,
 ) {
     verdiliste.forEach { element ->
@@ -41,11 +43,12 @@ fun håndterRekursivVerdiliste(
                     håndterVisningsvariant(
                         element.visningsVariant,
                         element,
+                        v2,
                         seksjon,
                     )
                 } else if (element.verdiliste != null && element.verdiliste.isNotEmpty()) {
                     seksjon.add(lagOverskriftH3(element.label).apply { setMarginLeft(marginVenstre) })
-                    håndterRekursivVerdiliste(element.verdiliste, seksjon, rekursjonsDybde + 1)
+                    håndterRekursivVerdiliste(element.verdiliste, seksjon, v2, rekursjonsDybde + 1)
                 } else if (element.verdi != null) {
                     seksjon.add(lagSpørsmålOgSvar(element).apply { setMarginLeft(marginVenstre) })
                 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
@@ -16,7 +16,7 @@ fun håndterVisningsvariant(
     if (verdilisteElement.verdiliste?.isNotEmpty() == true) {
         when (visningsVariant) {
             VisningsVariant.TABELL.toString() -> {
-                håndterTabeller(verdilisteElement.verdiliste, seksjon)
+                håndterTabell(verdilisteElement, seksjon)
             }
 
             VisningsVariant.PUNKTLISTE.toString() -> {
@@ -30,12 +30,10 @@ fun håndterVisningsvariant(
     }
 }
 
-private fun håndterTabeller(
-    verdiliste: List<VerdilisteElement>,
+private fun håndterTabell(
+    verdilisteElement: VerdilisteElement,
     seksjon: Div,
-) = verdiliste.forEach { verdilisteElement ->
-    verdiliste.let { seksjon.apply { add(lagTabell(verdilisteElement)) } }
-}
+) = verdilisteElement.let { seksjon.apply { add(lagTabell(verdilisteElement)) } }
 
 private fun håndterPunktliste(
     verdi: VerdilisteElement,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
@@ -11,12 +11,17 @@ import no.nav.familie.pdf.pdf.pdfElementer.lagTekstElement
 fun håndterVisningsvariant(
     visningsVariant: String,
     verdilisteElement: VerdilisteElement,
+    v2: Boolean,
     seksjon: Div,
 ) {
     if (verdilisteElement.verdiliste?.isNotEmpty() == true) {
         when (visningsVariant) {
             VisningsVariant.TABELL.toString() -> {
-                håndterTabell(verdilisteElement, seksjon)
+                if (v2) {
+                    håndterTabell(verdilisteElement, seksjon)
+                } else {
+                    håndterTabeller(verdilisteElement.verdiliste, seksjon)
+                }
             }
 
             VisningsVariant.PUNKTLISTE.toString() -> {
@@ -24,10 +29,17 @@ fun håndterVisningsvariant(
             }
 
             VisningsVariant.VEDLEGG.toString() -> {
-                håndterVedlegg(verdilisteElement.verdiliste, seksjon)
+                håndterVedlegg(verdilisteElement.verdiliste, seksjon, v2)
             }
         }
     }
+}
+
+private fun håndterTabeller(
+    verdiliste: List<VerdilisteElement>,
+    seksjon: Div,
+) = verdiliste.forEach { verdilisteElement ->
+    verdiliste.let { seksjon.apply { add(lagTabell(verdilisteElement)) } }
 }
 
 private fun håndterTabell(
@@ -50,6 +62,7 @@ private fun håndterPunktliste(
 private fun håndterVedlegg(
     verdiliste: List<VerdilisteElement>,
     seksjon: Div,
+    v2: Boolean,
 ) {
     val ingenVedlegg: String =
         hentOversettelse(
@@ -68,6 +81,6 @@ private fun håndterVedlegg(
                     },
                 )
             }
-        } ?: håndterRekursivVerdiliste(verdiliste, seksjon)
+        } ?: håndterRekursivVerdiliste(verdiliste, seksjon, v2)
     }
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
@@ -33,7 +33,7 @@ fun håndterVisningsvariant(
 private fun håndterTabell(
     verdilisteElement: VerdilisteElement,
     seksjon: Div,
-) = verdilisteElement.let { seksjon.apply { add(lagTabell(verdilisteElement)) } }
+) = seksjon.apply { add(lagTabell(verdilisteElement)) }
 
 private fun håndterPunktliste(
     verdi: VerdilisteElement,

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/InnholdsfortegnelseTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/InnholdsfortegnelseTest.kt
@@ -13,7 +13,7 @@ class InnholdsfortegnelseTest {
         val verdilisteElement = listOf(VerdilisteElement("", "Ja"), VerdilisteElement("Hei på deg", "Heihei!"))
         val seksjon = Div()
         // Act
-        håndterRekursivVerdiliste(verdilisteElement, seksjon)
+        håndterRekursivVerdiliste(verdilisteElement, seksjon, true)
         // Assert
         assertTrue(seksjon.children.size == 1)
     }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfElementUtilsTest.kt
@@ -2,11 +2,11 @@ package no.nav.familie.pdf.pdf
 
 import com.itextpdf.layout.element.Table
 import com.itextpdf.layout.element.Text
-import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedBarneTabell
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedFlereArbeidsforhold
 import no.nav.familie.pdf.no.nav.familie.pdf.pdf.utils.lagMedUtenlandsopphold
 import no.nav.familie.pdf.pdf.domain.FeltMap
+import no.nav.familie.pdf.pdf.domain.VerdilisteElement
 import no.nav.familie.pdf.pdf.pdfElementer.lagSpørsmålOgSvar
 import no.nav.familie.pdf.pdf.visningsvarianter.lagTabell
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -62,33 +62,24 @@ class PdfElementUtilsTest {
     // region tabell
     @ParameterizedTest
     @MethodSource("tabell")
-    fun `Utenlandsopphold sine objekter vises som Tabeller`(feltMap: FeltMap) {
+    fun `Utenlandsopphold, arbeidsforhold og barna dine sine objekter vises som Tabell`(feltMap: FeltMap) {
         // Arrange
-        val verdilisteElement = fåFørsteElementMedTabellVariant(feltMap)
-
+        val verdilisteElement = finnFørsteElementMedTabellVariant(feltMap.verdiliste)
         // Act
         val resultat =
-            if (verdilisteElement?.verdiliste != null) verdilisteElement.verdiliste?.map { lagTabell(it) } else null
+            if (verdilisteElement?.verdiliste != null) lagTabell(verdilisteElement) else null
 
         // Assert
-        assertNotNull(resultat, "Resultatet er null")
-        resultat.forEach {
-            assertNotNull(it, "Tabell er null")
-            assertTrue(it is Table, "Elementet er ikke en tabell")
-        }
+        assertNotNull(resultat, "Tabell er null")
+        assertTrue(resultat is Table, "Elementet er ikke en tabell")
     }
 
-    fun fåFørsteElementMedTabellVariant(feltMap: FeltMap): VerdilisteElement? {
-        fun traverse(verdiliste: List<VerdilisteElement>?): VerdilisteElement? {
-            verdiliste?.forEach { element ->
-                if (element.visningsVariant == "TABELL") {
-                    return element
-                }
-                traverse(element.verdiliste)?.let { return it }
-            }
-            return null
-        }
-        return traverse(feltMap.verdiliste)
-    }
+    fun finnFørsteElementMedTabellVariant(verdiliste: List<VerdilisteElement>): VerdilisteElement? =
+        verdiliste.firstOrNull { it.visningsVariant == "TABELL" }
+            ?: verdiliste
+                .asSequence()
+                .mapNotNull { it.verdiliste?.let(::finnFørsteElementMedTabellVariant) }
+                .firstOrNull()
+
     // endregion
 }

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -220,21 +220,6 @@ class PdfServiceTest {
     //endregion
 
     //region Tabeller
-    @ParameterizedTest
-    @MethodSource("tabell")
-    fun `Tabeller får inn en liste av objekter som tegnes som tabeller`(feltMap: FeltMap) {
-        // Assert
-        val pdfDoc = opprettPdf(feltMap)
-        val tekstIPdf = PdfTextExtractor.getTextFromPage(pdfDoc.getPage(2))
-
-        // Assert
-        val objekt1Index = tekstIPdf.indexOf("1")
-        val objekt2Index = tekstIPdf.indexOf("2", objekt1Index)
-        assertTrue(objekt1Index != -1)
-        assertTrue(objekt2Index != -1)
-        assertTrue(objekt1Index < objekt2Index)
-    }
-
     @Test
     fun `Tom verdi i tabell skal ikke krasje pdf-opprettelsen`() {
         // Arrange

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfServiceTest.kt
@@ -226,7 +226,7 @@ class PdfServiceTest {
         val feltMap = lagMedBarneTabell()
 
         // Act
-        val pdfDoc = pdfOppretterService.opprettPdf(feltMap)
+        val pdfDoc = pdfOppretterService.opprettPdf(feltMap, true)
 
         // Assert
         assertTrue(pdfDoc.isNotEmpty(), "Pdf-opprettelsen feilet, tom byteArray")

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfValidatorTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfValidatorTest.kt
@@ -18,7 +18,7 @@ class PdfValidatorTest {
     @BeforeAll
     fun setup() {
         val feltMap = JsonLeser.lesSøknadJson()
-        pdfBytes = pdfService.opprettPdf(feltMap)
+        pdfBytes = pdfService.opprettPdf(feltMap, true)
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/integrasjon/PdfControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/integrasjon/PdfControllerTest.kt
@@ -22,7 +22,7 @@ class PdfControllerTest : IntegrasjonSpringRunnerTest() {
 
         val response: ResponseEntity<ByteArray> =
             restTemplate.exchange(
-                localhost("/api/v1/pdf/opprett-pdf"),
+                localhost("/api/pdf/v1/opprett-pdf"),
                 HttpMethod.POST,
                 HttpEntity(feltMap, headers),
             )

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/testdata/FeltMaps.kt
@@ -115,11 +115,11 @@ fun lagMedBarneTabell(): FeltMap =
             listOf(
                 VerdilisteElement(
                     label = "Barna dine",
-                    visningsVariant = VisningsVariant.TABELL.toString(),
                     verdiliste =
                         listOf(
                             VerdilisteElement(
                                 label = "Barn 1",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
                                         VerdilisteElement(label = "Navn", verdi = "Kåre"),
@@ -127,6 +127,7 @@ fun lagMedBarneTabell(): FeltMap =
                             ),
                             VerdilisteElement(
                                 label = "Barn 2",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
                                         VerdilisteElement(label = "Navn", verdi = ""),
@@ -149,30 +150,25 @@ fun lagMedUtenlandsopphold(): FeltMap =
                     verdiliste =
                         listOf(
                             VerdilisteElement(
-                                label = "Utenlandsopphold",
+                                label = "Utenlandsopphold 1",
                                 visningsVariant = VisningsVariant.TABELL.toString(),
                                 verdiliste =
                                     listOf(
-                                        VerdilisteElement(
-                                            label = "Utenlandsopphold 1",
-                                            verdiliste =
-                                                listOf(
-                                                    VerdilisteElement(label = "Fra:", verdi = "2021-03-01"),
-                                                    VerdilisteElement(label = "Til:", verdi = "2021-04-01"),
-                                                    VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Danmark"),
-                                                    VerdilisteElement(label = "Hvorfor oppholdt du deg i Danmark?", verdi = "Ferie"),
-                                                ),
-                                        ),
-                                        VerdilisteElement(
-                                            label = "Utenlandsopphold 2",
-                                            verdiliste =
-                                                listOf(
-                                                    VerdilisteElement(label = "Fra:", verdi = "2021-04-01"),
-                                                    VerdilisteElement(label = "Til:", verdi = "2021-05-01"),
-                                                    VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Sverige"),
-                                                    VerdilisteElement(label = "Hvorfor oppholdt du deg i Sverige?", verdi = "Ferie"),
-                                                ),
-                                        ),
+                                        VerdilisteElement(label = "Fra:", verdi = "2021-03-01"),
+                                        VerdilisteElement(label = "Til:", verdi = "2021-04-01"),
+                                        VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Danmark"),
+                                        VerdilisteElement(label = "Hvorfor oppholdt du deg i Danmark?", verdi = "Ferie"),
+                                    ),
+                            ),
+                            VerdilisteElement(
+                                label = "Utenlandsopphold 2",
+                                visningsVariant = VisningsVariant.TABELL.toString(),
+                                verdiliste =
+                                    listOf(
+                                        VerdilisteElement(label = "Fra:", verdi = "2021-04-01"),
+                                        VerdilisteElement(label = "Til:", verdi = "2021-05-01"),
+                                        VerdilisteElement(label = "I hvilket land oppholdt du deg i?", verdi = "Sverige"),
+                                        VerdilisteElement(label = "Hvorfor oppholdt du deg i Sverige?", verdi = "Ferie"),
                                     ),
                             ),
                         ),

--- a/src/test/resources/overgangsstønad.json
+++ b/src/test/resources/overgangsstønad.json
@@ -116,10 +116,10 @@
     },
     {
       "label": "Barna dine",
-      "visningsVariant": "TABELL",
       "verdiliste": [
         {
           "label": "Barn 1",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Navn",

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -297,43 +297,38 @@
           "verdi": "Jeg er arbeidstaker (og/eller lønnsmottaker som frilanser)"
         },
         {
-          "label": "Om arbeidsforholdet ditt",
+          "label": "Arbeidsforhold 1",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
-              "label": "Arbeidsforhold 1",
-              "visningsVariant": "TABELL",
-              "verdiliste": [
-                {
-                  "label": "Navn på arbeidssted",
-                  "verdi": "Nav"
-                },
-                {
-                  "label": "Hvor mye jobber du?",
-                  "verdi": "100"
-                },
-                {
-                  "label": "Hva slags ansettelsesforhold har du?",
-                  "verdi": "Fast stilling"
-                }
-              ]
+              "label": "Navn på arbeidssted",
+              "verdi": "Nav"
             },
             {
-              "label": "Arbeidsforhold 2",
-              "visningsVariant": "TABELL",
-              "verdiliste": [
-                {
-                  "label": "Navn på arbeidssted",
-                  "verdi": "Bekk"
-                },
-                {
-                  "label": "Hvor mye jobber du?",
-                  "verdi": "100"
-                },
-                {
-                  "label": "Hva slags ansettelsesforhold har du?",
-                  "verdi": "Fast stilling"
-                }
-              ]
+              "label": "Hvor mye jobber du?",
+              "verdi": "100"
+            },
+            {
+              "label": "Hva slags ansettelsesforhold har du?",
+              "verdi": "Fast stilling"
+            }
+          ]
+        },
+        {
+          "label": "Arbeidsforhold 2",
+          "visningsVariant": "TABELL",
+          "verdiliste": [
+            {
+              "label": "Navn på arbeidssted",
+              "verdi": "Bekk"
+            },
+            {
+              "label": "Hvor mye jobber du?",
+              "verdi": "100"
+            },
+            {
+              "label": "Hva slags ansettelsesforhold har du?",
+              "verdi": "Fast stilling"
             }
           ]
         }

--- a/src/test/resources/søknad.json
+++ b/src/test/resources/søknad.json
@@ -73,42 +73,38 @@
           "verdi": "Ja"
         },
         {
-          "label": "Utenlandsopphold",
+          "label": "Utenlandsopphold 1",
           "visningsVariant": "TABELL",
           "verdiliste": [
             {
-              "label": "Utenlandsopphold 1",
-              "verdiliste": [
-                {
-                  "label": "Fra dato",
-                  "verdi": "01.01.2020"
-                },
-                {
-                  "label": "Til dato",
-                  "verdi": "01.01.2021"
-                },
-                {
-                  "label": "Land",
-                  "verdi": "Sverige"
-                }
-              ]
+              "label": "Fra dato",
+              "verdi": "01.01.2020"
             },
             {
-              "label": "Utenlandsopphold 2",
-              "verdiliste": [
-                {
-                  "label": "Fra dato",
-                  "verdi": "01.01.2021"
-                },
-                {
-                  "label": "Til dato",
-                  "verdi": "01.01.2022"
-                },
-                {
-                  "label": "Land",
-                  "verdi": "Danmark"
-                }
-              ]
+              "label": "Til dato",
+              "verdi": "01.01.2021"
+            },
+            {
+              "label": "Land",
+              "verdi": "Sverige"
+            }
+          ]
+        },
+        {
+          "label": "Utenlandsopphold 2",
+          "visningsVariant": "TABELL",
+          "verdiliste": [
+            {
+              "label": "Fra dato",
+              "verdi": "01.01.2021"
+            },
+            {
+              "label": "Til dato",
+              "verdi": "01.01.2022"
+            },
+            {
+              "label": "Land",
+              "verdi": "Danmark"
             }
           ]
         }
@@ -134,10 +130,10 @@
     },
     {
       "label": "Barna dine",
-      "visningsVariant": "TABELL",
       "verdiliste": [
         {
           "label": "Barn 1",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Navn",
@@ -219,6 +215,7 @@
         },
         {
           "label": "Barn 2",
+          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Har barnet samme adresse som deg?",
@@ -301,10 +298,10 @@
         },
         {
           "label": "Om arbeidsforholdet ditt",
-          "visningsVariant": "TABELL",
           "verdiliste": [
             {
               "label": "Arbeidsforhold 1",
+              "visningsVariant": "TABELL",
               "verdiliste": [
                 {
                   "label": "Navn på arbeidssted",
@@ -322,6 +319,7 @@
             },
             {
               "label": "Arbeidsforhold 2",
+              "visningsVariant": "TABELL",
               "verdiliste": [
                 {
                   "label": "Navn på arbeidssted",


### PR DESCRIPTION
Flyttet visningsvariant TABELL til Verdielementet som skal være tabell.

Før lå visningsvariant TABELL på foreldre-objektet, og alle verdielementene i verdlisten blir omgjort til tabeller.

Denne endringen gjør TABELL logikken mer lik PUNKTLISTE og VEDLEGG

[Søknad om overgangsstønad - enslig mor eller far - TABELL.pdf](https://github.com/user-attachments/files/19289010/Soknad.om.overgangsstonad.-.enslig.mor.eller.far.-.TABELL.pdf)

