### PR TITLE
Fjerner tabs fra søknad

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -1,5 +1,7 @@
 package no.nav.familie.pdf.pdf
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.itextpdf.io.source.ByteArrayOutputStream
 import no.nav.familie.pdf.pdf.PDFdokument.lagPdfADocument
 import no.nav.familie.pdf.pdf.PDFdokument.lagSøknadskvittering
@@ -9,7 +11,10 @@ class PdfService {
     fun opprettPdf(feltMap: FeltMap): ByteArray {
         val byteArrayOutputStream = ByteArrayOutputStream()
         val pdfADokument = lagPdfADocument(byteArrayOutputStream)
-        lagSøknadskvittering(pdfADokument, feltMap)
+        val test = jacksonObjectMapper().writeValueAsString(feltMap)
+        val test2 = test.replace("\\t", "")
+        val test3 = jacksonObjectMapper().readValue(test2, FeltMap::class.java)
+        lagSøknadskvittering(pdfADokument, test3)
 
         return byteArrayOutputStream.toByteArray()
     }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -11,10 +11,10 @@ class PdfService {
     fun opprettPdf(feltMap: FeltMap): ByteArray {
         val byteArrayOutputStream = ByteArrayOutputStream()
         val pdfADokument = lagPdfADocument(byteArrayOutputStream)
-        val test = jacksonObjectMapper().writeValueAsString(feltMap)
-        val test2 = test.replace("\\t", "")
-        val test3 = jacksonObjectMapper().readValue(test2, FeltMap::class.java)
-        lagSøknadskvittering(pdfADokument, test3)
+        val feltMapJson = jacksonObjectMapper().writeValueAsString(feltMap)
+        val feltMapJsonUtenTabs = feltMapJson.replace("\\t", "")
+        val feltMapUtenTabs = jacksonObjectMapper().readValue(feltMapJsonUtenTabs, FeltMap::class.java)
+        lagSøknadskvittering(pdfADokument, feltMapUtenTabs)
 
         return byteArrayOutputStream.toByteArray()
     }


### PR DESCRIPTION
Tabs som ikke er etter en newline skaper trøbbel ved pdfA1-validering. Dette er en midlertidig fix for å få gjennom en task som feiler i mottak.

En mer langsiktig fix er å validere at fritekst ikke kan inneholde tabs ved utfylling av søknad, slik at bruker ikke får sendt inn søknad før tabs er fjernet. Det er laget en egen favro på dette: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24939

Ønsker å fjerne denne koden når langsiktig løsning er implementert. Eller så burde vi kanskje fjerne denne koden igjen rett etter at tasken som feiler i prod er rekjørt? 