### PR TITLE
Skru på logg-splitting til Elastic og Loki

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -28,6 +28,11 @@ spec:
     requests:
       memory: 512Mi
       cpu: 20m
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-pdf.intern.dev.nav.no
   secureLogs:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -28,6 +28,11 @@ spec:
     requests:
       memory: 1Gi
       cpu: 100m
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-pdf.intern.nav.no
   secureLogs:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skrur på logg-splitting for app, som betyr at vi sender logs til både Elastic (Kibana) og (Grafana) Loki. Dette er en midlertidig løsning mens vi enda blir kjent med Loki og får satt opp ting slik vi ønsker det.

Favro: NAV-25157