### PR TITLE
Tillatt azure-token-generator i dev-gcp

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -66,6 +66,9 @@ spec:
         - application: skjemautfylling-preprod-alt
           namespace: skjemadigitalisering
           cluster: dev-gcp
+        - application: azure-token-generator
+          namespace: nais
+          cluster: dev-gcp
     outbound:
       external:
         - host: teamfamilie-unleash-api.nav.cloud.nais.io


### PR DESCRIPTION
For oss på team Fyllut-Sendinn hadde det vært nyttig om vi kunne bruke tokens fra azure-token-generator (https://doc.nais.io/auth/entra-id/how-to/generate/#grant-access) til å kalle tjenesten i dev-gcp under utvikling, slik at vi ikke trenger å kjøre opp familie-pdf lokalt.