### PR TITLE
Oppgraderer til ny mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <start-class>no.nav.familie.pdf.ApplicationKt</start-class>
         <itext.version>9.4.0</itext.version>
         <html2pdf.version>6.3.0</html2pdf.version>
-        <jackson.version>2.20.1</jackson.version>
+        <jackson.version>3.0.0</jackson.version>
         <swagger.version>2.2.40</swagger.version>
         <validation-model-jakarta.version>1.26.5</validation-model-jakarta.version>
         <jsoup.version>1.21.2</jsoup.version>
@@ -92,7 +92,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
+            <groupId>tools.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
             <version>${jackson.version}</version>
         </dependency>
@@ -110,12 +110,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-core</artifactId>

--- a/src/main/kotlin/no/nav/familie/pdf/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/config/ApplicationConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.pdf.config
 
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
 import no.nav.familie.log.filter.RequestTimeFilter
@@ -11,6 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
+import tools.jackson.module.kotlin.KotlinModule
 
 @SpringBootConfiguration
 @ComponentScan("no.nav.familie.pdf", "no.nav.familie.unleash")

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/PdfService.kt
@@ -1,6 +1,5 @@
 package no.nav.familie.pdf.pdf
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.itextpdf.io.source.ByteArrayOutputStream
 import no.nav.familie.pdf.infrastruktur.Toggle
 import no.nav.familie.pdf.infrastruktur.UnleashNextService
@@ -9,6 +8,7 @@ import no.nav.familie.pdf.pdf.PDFdokument.lagSøknadskvittering
 import no.nav.familie.pdf.pdf.domain.FeltMap
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 
 @Service
 class PdfService(
@@ -34,9 +34,10 @@ class PdfService(
 
         if (lagSøknadUtenTabs) {
             logger.info("Fant feature toggle for fjerning av tabs. Lager søknad uten tabs.")
-            val feltMapJson = jacksonObjectMapper().writeValueAsString(feltMap)
+            val mapper = jacksonMapperBuilder().build()
+            val feltMapJson = mapper.writeValueAsString(feltMap)
             val feltMapJsonUtenTabs = feltMapJson.replace("\\t", "")
-            val feltMapUtenTabs = jacksonObjectMapper().readValue(feltMapJsonUtenTabs, FeltMap::class.java)
+            val feltMapUtenTabs = mapper.readValue(feltMapJsonUtenTabs, FeltMap::class.java)
 
             lagSøknadskvittering(pdfADokument = pdfADokument, feltMap = feltMapUtenTabs, v2 = v2)
         } else {

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/lokalKjøring/JsonLeser.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/lokalKjøring/JsonLeser.kt
@@ -1,18 +1,17 @@
 package no.nav.familie.pdf.pdf.lokalKjøring
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.familie.pdf.pdf.domain.FeltMap
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 import java.io.FileNotFoundException
 import java.io.IOException
 
 object JsonLeser {
-    private val objectMapper: ObjectMapper =
-        jacksonObjectMapper()
+    private val jsonMapper: JsonMapper =
+        jacksonMapperBuilder()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .registerModule(JavaTimeModule())
+            .build()
 
     fun lesSøknadJson(): FeltMap = lesSøknadJson("/søknad.json")
 
@@ -23,7 +22,7 @@ object JsonLeser {
 
         return try {
             jsonInputStream.bufferedReader().use { reader ->
-                val result = objectMapper.readValue(reader, FeltMap::class.java)
+                val result = jsonMapper.readValue(reader, FeltMap::class.java)
                 result ?: throw ClassCastException("Uventet Json-format")
             }
         } catch (e: IOException) {


### PR DESCRIPTION
Det ble lite endringer her, da det ikke er noen klienter, bare 4 controllere.
Det er Ingen felter som starter med æøå i request eller response. Legger derfor ikke til `.enable(KotlinFeature.KotlinPropertyNameAsImplicitName` i jsonMapper, men burde kanskje gjøre det, tilfelle det blir lagt til felt som starter med æøå senere?

