### PR TITLE
Feature/visningstype underskrift

### DIFF
--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/VisningsVariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/VisningsVariant.kt
@@ -5,5 +5,5 @@ enum class VisningsVariant {
     VEDLEGG,
     PUNKTLISTE,
     HTML,
-    UNDERSKRIFT,
+    HOLDSAMMEN,
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/domain/VisningsVariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/domain/VisningsVariant.kt
@@ -5,4 +5,5 @@ enum class VisningsVariant {
     VEDLEGG,
     PUNKTLISTE,
     HTML,
+    UNDERSKRIFT,
 }

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
@@ -9,6 +9,7 @@ import com.itextpdf.layout.element.LineSeparator
 import com.itextpdf.layout.element.Paragraph
 import no.nav.familie.pdf.pdf.domain.FeltMap
 import no.nav.familie.pdf.pdf.domain.VerdilisteElement
+import no.nav.familie.pdf.pdf.domain.VisningsVariant
 import no.nav.familie.pdf.pdf.visningsvarianter.håndterVisningsvariant
 
 fun lagSeksjon(
@@ -16,7 +17,7 @@ fun lagSeksjon(
     v2: Boolean,
 ): Div =
     Div().apply {
-        StandardRoles.DIV
+        StandardRoles.DIV.apply { setKeepTogether(element.visningsVariant == VisningsVariant.UNDERSKRIFT.toString()) }
         add(
             lagOverskriftH2(element.label).apply {
                 setDestination(element.label)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
@@ -17,7 +17,8 @@ fun lagSeksjon(
     v2: Boolean,
 ): Div =
     Div().apply {
-        StandardRoles.DIV.apply { setKeepTogether(element.visningsVariant == VisningsVariant.HOLDSAMMEN.toString()) }
+        isKeepTogether = element.visningsVariant == VisningsVariant.HOLDSAMMEN.toString()
+        accessibilityProperties.role = StandardRoles.DIV
         add(
             lagOverskriftH2(element.label).apply {
                 setDestination(element.label)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/pdfElementer/Seksjoner.kt
@@ -17,7 +17,7 @@ fun lagSeksjon(
     v2: Boolean,
 ): Div =
     Div().apply {
-        StandardRoles.DIV.apply { setKeepTogether(element.visningsVariant == VisningsVariant.UNDERSKRIFT.toString()) }
+        StandardRoles.DIV.apply { setKeepTogether(element.visningsVariant == VisningsVariant.HOLDSAMMEN.toString()) }
         add(
             lagOverskriftH2(element.label).apply {
                 setDestination(element.label)

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
@@ -90,16 +90,6 @@ private fun håndterPunktliste(
         if (liste.size > 1) {
             seksjon.add(lagPunktliste(liste.drop(1)))
         }
-
-/*
-        seksjon.apply {
-            add(lagOverskriftH4(verdi.label).apply { setMarginLeft(30f) })
-            if (verdi.verdi != null) {
-                add(lagTekstElement(verdi.verdi).apply { setMarginLeft(30f) })
-            }
-            add(lagPunktliste(verdi.verdiliste).apply { setMarginLeft(30f) })
-        }
-*/
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
@@ -35,8 +35,8 @@ fun håndterVisningsvariant(
                     håndterVedlegg(verdilisteElement.verdiliste, seksjon, v2)
                 }
 
-                VisningsVariant.UNDERSKRIFT.toString() -> {
-                    håndterUnderskriftListe(verdilisteElement, seksjon)
+                VisningsVariant.HOLDSAMMEN.toString() -> {
+                    håndterHoldsammen(verdilisteElement, seksjon, v2)
                 }
             }
         }
@@ -55,9 +55,10 @@ private fun håndterTabell(
     seksjon: Div,
 ) = seksjon.apply { add(lagTabell(verdilisteElement)) }
 
-private fun håndterUnderskriftListe(
+private fun håndterHoldsammen(
     verdi: VerdilisteElement,
     seksjon: Div,
+    v2: Boolean,
 ) {
     if (verdi.verdiliste?.isNotEmpty() == true) {
         val liste = verdi.verdiliste
@@ -65,7 +66,7 @@ private fun håndterUnderskriftListe(
 
         verdi.verdi?.let { container.add(lagTekstElement(it)) }
 
-        håndterRekursivVerdiliste(liste, container, false, 1)
+        håndterRekursivVerdiliste(liste, container, v2)
         seksjon.add(container)
     }
 }
@@ -75,6 +76,22 @@ private fun håndterPunktliste(
     seksjon: Div,
 ) {
     if (verdi.verdiliste?.isNotEmpty() == true) {
+        val container = Div().apply { setKeepTogether(true) }
+        val liste = verdi.verdiliste
+        container.add(lagOverskriftH4(verdi.label))
+        verdi.verdi?.let { container.add(lagTekstElement(it)) }
+
+        // legg inn første element eksplisitt
+        container.add(lagPunktliste(listOf(liste.first())))
+
+        seksjon.add(container)
+
+        // resten av lista uten keepTogether
+        if (liste.size > 1) {
+            seksjon.add(lagPunktliste(liste.drop(1)))
+        }
+
+/*
         seksjon.apply {
             add(lagOverskriftH4(verdi.label).apply { setMarginLeft(30f) })
             if (verdi.verdi != null) {
@@ -82,6 +99,7 @@ private fun håndterPunktliste(
             }
             add(lagPunktliste(verdi.verdiliste).apply { setMarginLeft(30f) })
         }
+*/
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/HåndterVisningsvariant.kt
@@ -34,6 +34,10 @@ fun håndterVisningsvariant(
                 VisningsVariant.VEDLEGG.toString() -> {
                     håndterVedlegg(verdilisteElement.verdiliste, seksjon, v2)
                 }
+
+                VisningsVariant.UNDERSKRIFT.toString() -> {
+                    håndterUnderskriftListe(verdilisteElement, seksjon)
+                }
             }
         }
     }
@@ -50,6 +54,21 @@ private fun håndterTabell(
     verdilisteElement: VerdilisteElement,
     seksjon: Div,
 ) = seksjon.apply { add(lagTabell(verdilisteElement)) }
+
+private fun håndterUnderskriftListe(
+    verdi: VerdilisteElement,
+    seksjon: Div,
+) {
+    if (verdi.verdiliste?.isNotEmpty() == true) {
+        val liste = verdi.verdiliste
+        val container = Div().apply { setKeepTogether(true) }
+
+        verdi.verdi?.let { container.add(lagTekstElement(it)) }
+
+        håndterRekursivVerdiliste(liste, container, false, 1)
+        seksjon.add(container)
+    }
+}
 
 private fun håndterPunktliste(
     verdi: VerdilisteElement,

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/Punktliste.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/Punktliste.kt
@@ -12,7 +12,7 @@ fun lagPunktliste(verdiListe: List<VerdilisteElement>): com.itextpdf.layout.elem
                 StandardRoles.L
                 setListSymbol("\u2022 ")
                 symbolIndent = 8f
-                isKeepTogether = true
+                // isKeepTogether = true
             }
     verdiListe.forEach {
         list.add(ListItem(it.label)).apply {

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/Punktliste.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/visningsvarianter/Punktliste.kt
@@ -12,7 +12,6 @@ fun lagPunktliste(verdiListe: List<VerdilisteElement>): com.itextpdf.layout.elem
                 StandardRoles.L
                 setListSymbol("\u2022 ")
                 symbolIndent = 8f
-                // isKeepTogether = true
             }
     verdiListe.forEach {
         list.add(ListItem(it.label)).apply {

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfControllerTest.kt
@@ -32,6 +32,15 @@ internal class PdfControllerTest {
         val textByPage = `Test av skjema`("/gravferdsstønad.json", "delme-1.pdf")
 
         assertTrue(textByPage[1].contains("I tillegg til dette skjemaet"))
+
+        // Verifiser at underskriftseksjonen er samlet på en side
+        val page5 = textByPage[4]
+        assertTrue(
+            page5.contains("Søker\n") &&
+                page5.contains("Sted og dato:") &&
+                page5.contains("Navn med blokkbokstaver:"),
+        )
+        assertEquals(1, page5.split("Navn med blokkbokstaver:").size - 1)
     }
 
     @Test
@@ -46,6 +55,16 @@ internal class PdfControllerTest {
         val textByPage = `Test av skjema`("/avtale-om-medfinansiering.json", "delme-3.pdf")
 
         assertTrue(textByPage[0].contains("Forskriften §14-1"))
+
+        // Verifiser at underskriftseksjonen er samlet på en side
+        val page3 = textByPage[2]
+        assertTrue(
+            page3.contains("Underskrift\n") &&
+                page3.contains("Ordfører/rådmann") &&
+                page3.contains("Daglig leder i tiltaksbedriften") &&
+                page3.contains("Leder Nav-kontor"),
+        )
+        assertEquals(3, page3.split("Navn med blokkbokstaver:").size - 1)
     }
 
     @Test

--- a/src/test/resources/arbeid-utdannings-søknad.json
+++ b/src/test/resources/arbeid-utdannings-søknad.json
@@ -53,7 +53,7 @@
       "verdiliste": [
         {
           "label": "Gjelder søknaden reise til arbeid eller reise til utdanning?",
-          "verdi": null,
+          "verdi": "Undertekst eksempel.",
           "verdiliste": [
             {
               "label": "Reise til utdanning"
@@ -301,7 +301,8 @@
           "label": "Navn med blokkbokstaver",
           "verdi": " "
         }
-      ]
+      ],
+      "visningsVariant": "UNDERSKRIFT"
     }
   ],
   "bunntekst": {

--- a/src/test/resources/arbeid-utdannings-søknad.json
+++ b/src/test/resources/arbeid-utdannings-søknad.json
@@ -60,6 +60,54 @@
             },
             {
               "label": "Reise til arbeid"
+            },
+            {
+              "label": "Reise fra utdanning"
+            },
+            {
+              "label": "Reise fra arbeid"
+            },
+            {
+              "label": "Reise til ferie"
+            },
+            {
+              "label": "Reise fra ferie"
+            },
+            {
+              "label": "Reise til utdanning2"
+            },
+            {
+              "label": "Reise til arbeid2"
+            },
+            {
+              "label": "Reise fra utdanning2"
+            },
+            {
+              "label": "Reise fra arbeid2"
+            },
+            {
+              "label": "Reise til ferie2"
+            },
+            {
+              "label": "Reise fra ferie2"
+            },
+            {
+              "label": "Reise til utdanning32"
+            },
+            {
+              "label": "Reise til arbeid3"
+            },
+            {
+              "label": "Reise fra utdanning3"
+            },
+            {
+              "label": "Reise fra arbeid3"
+            },
+            {
+              "label": "Reise til ferie3"
+            },
+            {
+              "label": "Reise fra ferie3"
             }
           ],
           "visningsVariant": "PUNKTLISTE"
@@ -302,7 +350,7 @@
           "verdi": " "
         }
       ],
-      "visningsVariant": "UNDERSKRIFT"
+      "visningsVariant": "HOLDSAMMEN"
     }
   ],
   "bunntekst": {

--- a/src/test/resources/avtale-om-medfinansiering.json
+++ b/src/test/resources/avtale-om-medfinansiering.json
@@ -141,7 +141,7 @@
           ]
         }
       ],
-      "visningsVariant": "UNDERSKRIFT"
+      "visningsVariant": "HOLDSAMMEN"
     }
   ],
   "bunntekst": {

--- a/src/test/resources/avtale-om-medfinansiering.json
+++ b/src/test/resources/avtale-om-medfinansiering.json
@@ -32,6 +32,12 @@
           "verdi": "50",
           "verdiliste": null,
           "visningsVariant": null
+        },
+        {
+          "label": "<h4>Forskriften §14-8. 2. ledd</h4><p>Tillegg for testing av at underskriftene ikke brytes over flere sider</p>",
+          "verdi": null,
+          "verdiliste": null,
+          "visningsVariant": "HTML"
         }
       ],
       "visningsVariant": null
@@ -134,7 +140,8 @@
             }
           ]
         }
-      ]
+      ],
+      "visningsVariant": "UNDERSKRIFT"
     }
   ],
   "bunntekst": {

--- a/src/test/resources/barnetilsyn.json
+++ b/src/test/resources/barnetilsyn.json
@@ -269,6 +269,43 @@
       ]
     },
     {
+      "label": "Arbeid, utdanning og andre aktiviteter2",
+      "verdiliste": [
+        {
+          "label": "Hva er din arbeidssituasjon?",
+          "verdiliste": [
+            {
+              "label": "Svaralternativ",
+              "visningsVariant": "PUNKTLISTE",
+              "verdiliste": [
+                {
+                  "label": "Jeg er arbeidstaker (og/eller lønnsmottaker som frilanser)"
+                },
+                {
+                  "label": "Jeg er selvstendig næringsdrivende eller frilanser med enkeltpersonforetak"
+                },
+                {
+                  "label": "Jeg er selvstendig næringsdrivende og ansatt i mitt eget aksjeselskap (AS)"
+                },
+                {
+                  "label": "Jeg etablerer egen virksomhet"
+                }
+              ]
+            },
+            {
+              "label": "Svar",
+              "visningsVariant": "PUNKTLISTE",
+              "verdiliste": []
+            }
+          ]
+        },
+        {
+          "label": "Er du i arbeid?",
+          "verdi": "Nei, jeg er ikke i arbeid fordi jeg er syk"
+        }
+      ]
+    },
+    {
       "label": "Når søker du stønad fra?",
       "verdiliste": [
         {

--- a/src/test/resources/gravferdsstønad.json
+++ b/src/test/resources/gravferdsstønad.json
@@ -453,7 +453,7 @@
           ]
         }
       ],
-      "visningsVariant": "UNDERSKRIFT"
+      "visningsVariant": "HOLDSAMMEN"
     }
   ],
   "bunntekst": {

--- a/src/test/resources/gravferdsstønad.json
+++ b/src/test/resources/gravferdsstønad.json
@@ -452,7 +452,8 @@
             }
           ]
         }
-      ]
+      ],
+      "visningsVariant": "UNDERSKRIFT"
     }
   ],
   "bunntekst": {


### PR DESCRIPTION
Har laget en ny visningstype=HOLDSAMMEN som skal signalisere at denne seksjonen så langt som mulig skal være samlet på en side i den genererte PDFen. Vi vil bruke den på de skjema der vi har lagt til en signaturliste. Effekten vil være at dersom det er plass på en side vil signaturlisten legges inn der. Hvis ikke, så vil den starte på en ny side.
Har også gjort en liten endring i hvordan PUNKTLISTE blir vist. Dette for å unngå at punktlistens overskrift kommer på en side og punktene på neste. Nå vil minimum overskrift og førte punkt vises på samme side.
Merk at for seksjoner som ikke er markert med visningstype=HOLDSAMMEN, kan man få seksjonsoverskrift på bunnen av en side og resten av seksjonen på neste. 