### PR TITLE
Bumper avhengigheter og fikser bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
 WORKDIR /app
 ENV TZ="Europe/Oslo"
 COPY target/familie-pdf.jar app.jar
 ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75"
-CMD ["app.jar"]
+CMD ["-jar", "app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
         <springdoc.version>3.0.3</springdoc.version>
         <jupiter.version>6.0.1</jupiter.version>
         <mockk.version>1.14.11</mockk.version>
-        <felles.version>4.20260529121328_2754f7c</felles.version>
+        <felles.version>4.20260714100416_2aeb670</felles.version>
         <token-validation.version>6.0.11</token-validation.version>
         <start-class>no.nav.familie.pdf.ApplicationKt</start-class>
-        <itext.version>9.6.0</itext.version>
-        <html2pdf.version>6.3.2</html2pdf.version>
-        <jackson.version>3.2.0</jackson.version>
+        <itext.version>9.7.0</itext.version>
+        <html2pdf.version>6.3.3</html2pdf.version>
+        <jackson.version>3.2.1</jackson.version>
         <swagger.version>2.2.52</swagger.version>
         <validation-model-jakarta.version>1.30.2</validation-model-jakarta.version>
         <jsoup.version>1.22.2</jsoup.version>
@@ -53,6 +53,19 @@
             <url>https://maven.pkg.github.com/navikt/familie-felles</url>
         </repository>
     </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- unleash-client-java (via okhttp-eventsource) og mock-oauth2-server (via mockwebserver)
+                 drar inn ulike major-versjoner av okhttp3, som ikke er binærkompatible.
+                 Tvinger samme versjon for å unngå NoSuchMethodError i klassestien. -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>5.2.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-resttestclient</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -20,18 +20,18 @@
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
         <kotlin.version>2.3.10</kotlin.version>
-        <springdoc.version>3.0.0</springdoc.version>
+        <springdoc.version>3.0.3</springdoc.version>
         <jupiter.version>6.0.1</jupiter.version>
-        <mockk.version>1.14.6</mockk.version>
+        <mockk.version>1.14.11</mockk.version>
         <felles.version>4.20260301040348_4280733</felles.version>
-        <token-validation.version>6.0.1</token-validation.version>
+        <token-validation.version>6.0.11</token-validation.version>
         <start-class>no.nav.familie.pdf.ApplicationKt</start-class>
         <itext.version>9.5.0</itext.version>
-        <html2pdf.version>6.3.0</html2pdf.version>
+        <html2pdf.version>6.3.2</html2pdf.version>
         <jackson.version>3.1.0</jackson.version>
-        <swagger.version>2.2.40</swagger.version>
+        <swagger.version>2.2.52</swagger.version>
         <validation-model-jakarta.version>1.28.2</validation-model-jakarta.version>
-        <jsoup.version>1.22.1</jsoup.version>
+        <jsoup.version>1.22.2</jsoup.version>
 
     </properties>
 
@@ -225,7 +225,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.14</version>
+                        <version>0.8.15</version>
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>
@@ -260,7 +260,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.14</version>
+                    <version>0.8.15</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -371,7 +371,7 @@
                 <!-- For å få dependency graph i SLSA som pushes av docker-build-push parameter byosbom -->
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.9.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
     </parent>
 
     <properties>
@@ -19,18 +19,18 @@
         <revision>1.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
-        <kotlin.version>2.3.10</kotlin.version>
+        <kotlin.version>2.4.0</kotlin.version>
         <springdoc.version>3.0.0</springdoc.version>
         <jupiter.version>6.0.1</jupiter.version>
         <mockk.version>1.14.6</mockk.version>
-        <felles.version>4.20260301040348_4280733</felles.version>
+        <felles.version>4.20260529121328_2754f7c</felles.version>
         <token-validation.version>6.0.1</token-validation.version>
         <start-class>no.nav.familie.pdf.ApplicationKt</start-class>
-        <itext.version>9.5.0</itext.version>
+        <itext.version>9.6.0</itext.version>
         <html2pdf.version>6.3.0</html2pdf.version>
-        <jackson.version>3.1.0</jackson.version>
+        <jackson.version>3.2.0</jackson.version>
         <swagger.version>2.2.40</swagger.version>
-        <validation-model-jakarta.version>1.28.2</validation-model-jakarta.version>
+        <validation-model-jakarta.version>1.30.2</validation-model-jakarta.version>
         <jsoup.version>1.22.1</jsoup.version>
 
     </properties>

--- a/src/main/kotlin/no/nav/familie/pdf/pdf/Metadata.kt
+++ b/src/main/kotlin/no/nav/familie/pdf/pdf/Metadata.kt
@@ -65,8 +65,9 @@ private fun lagXmpMeta(
                 "pdfuaid:part",
                 "1",
             )
-            // Sett revisjonsåret for samsvarsstandarden til det nåværende året
-            setProperty("http://www.aiim.org/pdfua/ns/id/", "pdfuaid:rev", getCurrentYear())
+            // "pdfuaid:rev" skal være revisjonsåret til selve ISO 14289-2-spesifikasjonen (2024),
+            // ikke dagens dato, jf. ISO_14289_2 clause=5 testNumber=5
+            setProperty("http://www.aiim.org/pdfua/ns/id/", "pdfuaid:rev", "2024")
 
             // Registrer namespaces
             XMPMetaFactory.getSchemaRegistry().registerNamespace("http://purl.org/dc/terms/", "dc")
@@ -79,8 +80,3 @@ private fun lagXmpMeta(
         }
     return xmpMeta
 }
-
-private fun getCurrentYear(): String =
-    java.time.Year
-        .now()
-        .toString()

--- a/src/test/kotlin/no/nav/familie/pdf/pdf/PdfControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/pdf/pdf/PdfControllerTest.kt
@@ -1,7 +1,6 @@
 package no.nav.familie.pdf.no.nav.familie.pdf.pdf
 
 import com.itextpdf.kernel.pdf.PdfDocument
-import com.itextpdf.kernel.pdf.PdfName
 import com.itextpdf.kernel.pdf.PdfReader
 import com.itextpdf.kernel.pdf.canvas.parser.PdfTextExtractor
 import com.itextpdf.kernel.pdf.tagging.IStructureNode
@@ -374,16 +373,7 @@ internal class PdfControllerTest {
     /** Safe role string getter (handles different API shapes) */
     private fun safeRoleString(elem: PdfStructElem): String =
         try {
-            val role = elem.role
-            // role may be PdfName or String
-            when (role) {
-                is PdfName -> role.toString().removePrefix("/")
-
-                // /P etc
-                is String -> role
-
-                else -> role?.toString() ?: "?"
-            }
+            elem.role?.toString()?.removePrefix("/") ?: "?"
         } catch (_: Throwable) {
             "?"
         }


### PR DESCRIPTION
# Bumper avhengigheter og fikser bugs

### Hvorfor er denne endringen nødvendig? ✨ 

Vi ønsker å bumpe avhengigheten og må gjøre noen tiltak for å passe på at appen klarer å innhente endringene. 

- Manglende test-avhengighet. Ny versjon av mockk (1.14.11) drar ikke lenger med seg `junit-jupiter-params` automatisk slik den gamle gjorde. Testene som bruker `@ParameterizedTest` kompilerte ikke uten at vi la den til selv i `pom.xml`.

- Død kode i en test. Kotlin 2.4 er strengere og stoppet bygget på grunn av en sjekk i en test (`safeRoleString`) som aldri kunne bli sann. Fjernet den unødvendige grenen.

- Bug i PDF metadata. Vi fant ut at PDFene  satte feil verdi i metadataen `pdfuaid:rev` – koden brukte **inneværende år** (f.eks. 2026), mens PDF/UA-2-standarden krever at denne alltid skal være **"2024"** (året standarden ble publisert). Dette har vært feil hele tiden, men ble først oppdaget nå fordi den nye valideringsbiblioteket (veraPDF) sjekker dette strengere enn den gamle versjonen gjorde. Rettet til riktig fast verdi.

- Konflikt mellom to versjoner av samme bibliotek (okhttp). Oppgraderingen av familie-felles dro med seg en nyere versjon av et bibliotek (unleash) som bruker okhttp versjon 4, mens et annet bibliotek vi bruker i tester (mock-oauth2-server) bruker okhttp versjon 5. Disse to versjonene er ikke kompatible med hverandre, og når begge lå i klassepathen samtidig krasjet testene med en merkelig feil (`NoSuchMethodError`). Løste det ved å tvinge prosjektet til å bruke kun én versjon av okhttp.

### Verdt å nevne

- Har deployet til preprod og sendt inn en søknad, sjekket PDF