### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -26,7 +26,7 @@ spec:
     limits:
       memory: 2Gi
     requests:
-      memory: 512Mi
+      memory: 2Gi
       cpu: 20m
   observability:
     logging:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -26,7 +26,7 @@ spec:
     limits:
       memory: 4Gi
     requests:
-      memory: 1Gi
+      memory: 4Gi
       cpu: 100m
   observability:
     logging:


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
