### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -24,10 +24,10 @@ spec:
     max: 2
   resources:
     limits:
-      memory: 2Gi
+      memory: 1Gi
     requests:
-      memory: 2Gi
-      cpu: 20m
+      memory: 1Gi
+      cpu: 75m
   observability:
     logging:
       destinations:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -24,10 +24,10 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 4Gi
+      memory: 1Gi
     requests:
-      memory: 4Gi
-      cpu: 100m
+      memory: 1Gi
+      cpu: 300m
   observability:
     logging:
       destinations:


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.